### PR TITLE
Fix FormTypeClassValidatorTest on PHPUnit 12.2 (Symfony 8.x CI)

### DIFF
--- a/tests/Validator/Constraints/FormTypeClassValidatorTest.php
+++ b/tests/Validator/Constraints/FormTypeClassValidatorTest.php
@@ -199,9 +199,10 @@ class FormTypeClassValidatorTest extends TestCase
         $validator = new FormTypeClassValidator($formTypes);
 
         $messages = [];
-        $builder = $this->createStub(ConstraintViolationBuilderInterface::class);
-        $builder->method('setParameter')->willReturn($builder);
-        $builder->method('atPath')->willReturn($builder);
+        // Reuse the concrete stub: ConstraintViolationBuilderInterface's fluent methods return
+        // `static`, which the PHPUnit version pinned by simple-phpunit on the Symfony 8.x matrix
+        // (12.2) cannot mock via createStub() (works on 12.5 locally, fails on CI).
+        $builder = new ConstraintViolationBuilderStub();
 
         $context = $this->createStub(ExecutionContextInterface::class);
         $context->method('buildViolation')->willReturnCallback(static function (string $message) use (&$messages, $builder): ConstraintViolationBuilderInterface {


### PR DESCRIPTION
## Summary

Fixes the 4 PHPUnit errors on the **Symfony 8.x / PHP 8.5** CI matrix:

> `MethodCannotBeConfiguredException: Trying to configure method "setParameter" which cannot be configured because it ... is ... static`

`captureMessages()` stubbed `ConstraintViolationBuilderInterface` and configured `setParameter()`, whose return type is `static`. The PHPUnit version `symfony/phpunit-bridge`'s `simple-phpunit` pins on that matrix (**12.2**) cannot configure a `static`-returning method via `createStub()`. It passed locally only because we run **12.5**. `setParameter` was the only such method configured — the tests that pass CI (incl. others in this same file, and `NewEmailAddressValidatorTest`) only ever configure `atPath` or use the concrete stub.

**Fix:** reuse the file's existing concrete `ConstraintViolationBuilderStub` (real fluent methods, zero mocking) for the builder — the exact pattern the file's other violation tests already use and which passes CI. The context stub (returns the interface, not `static`) is unchanged.

No production changes. Full validator suite green locally.