### PR TITLE
Fix uploaded files disappearing on publish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -600,6 +600,25 @@ References: `src/Factory/Uploadable/MediaObjectFactory.php` (`isImagineProcessab
 
 ---
 
+### Deleted-file markers are keyed per resource, never per property name ✓ **DONE**
+
+A `PATCH {"file": null}` clears an uploadable field. `UploadableNormalizer` records that intent so `UploadableFileManager::persistFiles()` can tell "no file submitted" from "the file was explicitly removed" — the payload looks identical either way.
+
+That marker **must be keyed on the resource being written**, held in the `\WeakMap<object, list<string>> $deletedFields` on `UploadableFileManager`. It was previously an `ArrayCollection` of bare storage-property names. `filename` is the default storage property of *every* `UploadableField`, so the marker matched any resource written afterwards, and nothing ever cleared the collection. Under **FrankenPHP worker mode** the shared service outlives the request: one admin file deletion poisoned every later write in that worker that carried no new file — a publish `PATCH {publishedAt}` being exactly that — silently deleting an unrelated resource's file and nulling its path. Symptom: the component survives with its text intact, only the file vanishes, intermittently, and never in dev (which does not run the worker Caddyfile).
+
+Consequences for future work here:
+- `addDeletedField(object $object, string $field)` takes the resource. `UploadableNormalizer::denormalize()` registers markers **after** `$this->denormalizer->denormalize(...)` returns, because only then does the object exist. For a published publishable resource that object is the draft from `PublishableNormalizer::createDraft`, which is why clearing a file on a published resource clears it on the draft and leaves the published file alone.
+- Publishing continues the write against the *published* instance, so `PublishableEventListener::mergeDraftIntoPublished()` calls `transferDeletedFields($draft, $published)`. Without it, a single request that clears a file **and** publishes would silently stop clearing.
+- A `WeakMap` (not a plain map plus `kernel.reset`) so entries die with the objects — the service cannot accumulate state across requests under any runtime.
+
+**Worker mode makes request-scoped state on a shared service a whole class of bug.** Any new bundle service holding mutable per-request state needs the same treatment.
+
+Tests: `tests/Helper/Uploadable/UploadableFileManagerTest.php` (cross-object leak, marker still works for its own object, no marker means no deletion, marker follows a merge). Behat asserts the *stored object* survives a publish — `the file for the resource :name should exist in its configured filestore` — on all four merge scenarios in `features/uploads/uploads.feature`; the pre-existing "valid download link" step only string-compares a URL built from the IRI, and the schemas only prove `filename` is non-null, so neither could catch a deleted file.
+
+References: `src/Helper/Uploadable/UploadableFileManager.php`, `src/Serializer/Normalizer/UploadableNormalizer.php`, `src/EventListener/Api/PublishableEventListener.php`.
+
+---
+
 ### #194 — Uploads silently overwrite another resource's file on filename collision — store under original name + unique token ✓ **DONE**
 
 **Implemented** in `UploadableFileManager::persistFiles()`: files are now stored as `<sanitised-stem>-<token>.<ext>` (`tokeniseFilename()` — slugified stem, length-capped, `bin2hex(random_bytes(4))` token), with a `fileExists()` regeneration loop guaranteeing no upload ever overwrites another resource's file. Data-URI uploads (`UploadedDataUriFile`) keep their UUID name (no token). The original name is resolved by `resolveOriginalName()` which **prefers whichever candidate carries a file extension** — for real multipart uploads that's `getClientOriginalName()` (the on-disk file is a temp name), but in some contexts (incl. the Behat harness) the client name is absent/the form field and the file's own basename holds the real name+ext. Behat: `features/uploads/uploads.feature` "Uploading keeps the original filename with a unique token…" (one real multipart upload + a second same-source resource via a `persistFiles` helper — two consecutive authed multipart POSTs 401/415 in the harness, so that path is avoided). Content-disposition download scenarios switched from exact `filename=image.png` to `should contain "filename=image-"`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,33 @@ References: `src/Helper/Uploadable/UploadableFileManager.php`, `src/Serializer/N
 
 ---
 
+### Stored files are never deleted before their replacement is in place ✓ **DONE**
+
+Two rules govern every write that changes an uploadable's stored path:
+
+1. **Delete after, not before.** `PublishableEventListener::mergeDraftIntoPublished()` snapshots the published resource's paths with `getStoredFilePaths()`, runs the copy, then calls `deleteOrphanedFiles($publishedResource, $previousPaths)`. It used to call `deleteFiles($publishedResource)` *first*, inside a `catch` that swallowed the exception, so any failure in the copy left the resource pointing at a file that no longer existed.
+2. **Never delete a path the resource still references.** `deleteOrphanedFiles()` compares each field's previous path with its current one and skips anything unchanged. Draft and published can legitimately share a stored path — `copyFilepath()` keeps the original path when the source is missing from the filestore — and the old code deleted it, taking the file the published resource had just inherited.
+
+Publishing a draft that genuinely has no file still clears the published file (previous path set, current null → delete): that behaviour is unchanged.
+
+`copyFilepath()` writes a clone's copy **beside the original**, preserving the field's `prefix` (it previously built the path from `pathinfo()['filename']`, dropping the directory), under the same tokenised naming as every other stored file, stripping an existing token first so repeated draft/publish cycles do not accumulate one per cycle. When the source object is missing it returns the **original path** rather than null — nulling turned a recoverable storage problem into permanent loss, because the next publish copied that null over the published resource's own path.
+
+**Behat cannot reach the shared-path case through the API** (cloning always copies the file), so `the resource :resource has the same file as the resource :other` sets it up directly. Verified to fail against the old ordering before the fix landed.
+
+References: `src/Helper/Uploadable/UploadableFileManager.php` (`getStoredFilePaths`, `deleteOrphanedFiles`, `removeFilepathValue`, `copyFilepath`), `src/EventListener/Api/PublishableEventListener.php`.
+
+---
+
+### Services holding request-scoped state must be tagged `kernel.reset` ✓ **DONE**
+
+`ResetInterface` alone does nothing — a service is only reset between requests if it carries the `kernel.reset` tag. Autoconfiguration adds it, but **this is a bundle**: an application may disable autoconfiguration, and several of the bundle's own definitions already opt out with `->autoconfigure(false)`. Nothing was tagged, so `CwaCollectorData::reset()` and `JWTEventListener::reset()` were unreachable as far as the framework was concerned.
+
+Tagged explicitly: `mercure.resource_publisher` and `http_cache.purger` (queue changed objects), `data_collector.data` (profiler panel data), `jwt_event_listener` (holds the JWT to write as a cookie). `MercureResourcePublisher::reset()` also lowers `isPropagating`, so a request dying inside `propagate()` cannot leave the re-entrancy guard raised and suppress every publish for the rest of a worker's life.
+
+`tests/DependencyInjection/ServicesResetterTest.php` asserts each is registered with the `services_resetter`. **Add to its list whenever a bundle service gains mutable per-request state** — or better, scope the state so it cannot outlive its request, as `UploadableFileManager` does with a `WeakMap`. (The test is reported Risky: booting a kernel in debug registers Symfony's ErrorHandler and it cannot be handed back. Risky is not a failure and `failOnRisky` is unset.)
+
+---
+
 ### #194 — Uploads silently overwrite another resource's file on filename collision — store under original name + unique token ✓ **DONE**
 
 **Implemented** in `UploadableFileManager::persistFiles()`: files are now stored as `<sanitised-stem>-<token>.<ext>` (`tokeniseFilename()` — slugified stem, length-capped, `bin2hex(random_bytes(4))` token), with a `fileExists()` regeneration loop guaranteeing no upload ever overwrites another resource's file. Data-URI uploads (`UploadedDataUriFile`) keep their UUID name (no token). The original name is resolved by `resolveOriginalName()` which **prefers whichever candidate carries a file extension** — for real multipart uploads that's `getClientOriginalName()` (the on-disk file is a temp name), but in some contexts (incl. the Behat harness) the client name is absent/the form field and the file's own basename holds the real name+ext. Behat: `features/uploads/uploads.feature` "Uploading keeps the original filename with a unique token…" (one real multipart upload + a second same-source resource via a `persistFiles` helper — two consecutive authed multipart POSTs 401/415 in the harness, so that path is avoided). Content-disposition download scenarios switched from exact `filename=image.png` to `should contain "filename=image-"`.

--- a/features/bootstrap/UploadsContext.php
+++ b/features/bootstrap/UploadsContext.php
@@ -72,7 +72,7 @@ class UploadsContext implements Context
      */
     public function removeFile(): void
     {
-        foreach (['dummy_uploadable', 'first_upload', 'second_upload'] as $key) {
+        foreach (['dummy_uploadable', 'dummy_uploadable_draft', 'first_upload', 'second_upload'] as $key) {
             if (isset($this->restContext->resources[$key])) {
                 try {
                     $this->uploadableHelper->deleteFiles($this->iriConverter->getResourceFromIri($this->restContext->resources[$key]));

--- a/features/bootstrap/UploadsContext.php
+++ b/features/bootstrap/UploadsContext.php
@@ -218,6 +218,22 @@ class UploadsContext implements Context
     }
 
     /**
+     * Two resources referencing one stored file cannot be produced through the API — cloning a draft
+     * copies the file. It happens in the wild when the copy could not be made (the source was missing
+     * at draft time) or when app code assigns a path directly, and it is the case a publish must not
+     * get wrong: the file the published resource ends up pointing at must survive the merge.
+     *
+     * @Given the resource :resource has the same file as the resource :other
+     */
+    public function theResourceHasTheSameFileAsTheResource(string $resourceName, string $otherName): void
+    {
+        $resource = $this->iriConverter->getResourceFromIri($this->restContext->resources[$resourceName]);
+        $other = $this->iriConverter->getResourceFromIri($this->restContext->resources[$otherName]);
+        $resource->setFilename($other->getFilename());
+        $this->manager->flush();
+    }
+
+    /**
      * @When /^I request the download endpoint(?: with the postfix "(.+)")?$/
      */
     public function iRequestTheDownloadEndpoint(?string $postfix = null)

--- a/features/uploads/uploads.feature
+++ b/features/uploads/uploads.feature
@@ -263,6 +263,22 @@ Feature: API Resources which can have files uploaded
     And the resource "dummy_uploadable" should have a filename matching "#^components/image-[0-9a-f]{8}\.svg$#"
     And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
+  # The merge deletes the file the published resource stops referencing. When the draft carries the
+  # same stored path, that file is the one the published resource still points at, so nothing may be
+  # deleted — the old delete-before-copy order destroyed it and left a dangling path behind.
+  @loginAdmin
+  Scenario: Publishing a draft that shares the published resource's stored file keeps that file
+    Given there is a DummyUploadableAndPublishable with a draft
+    And the resource "dummy_uploadable_draft" has the same file as the resource "dummy_uploadable"
+    And I add "Content-Type" header equal to "application/merge-patch+json"
+    When I send a "PATCH" request to the resource "dummy_uploadable_draft" with data:
+      | publishedAt               |
+      | 1970-11-11T23:59:59+00:00 |
+    Then the response status code should be 200
+    And the response should be the resource "dummy_uploadable"
+    And the resource "dummy_uploadable" should have a filename matching "#^components/image-[0-9a-f]{8}\.png$#"
+    And the file for the resource "dummy_uploadable" should exist in its configured filestore
+
   # A draft that was never published has no publishedResource, so checkMergeDraftIntoPublished returns
   # early - no merge and no file deletion - and the resource keeps its own IRI once published.
   @loginAdmin

--- a/features/uploads/uploads.feature
+++ b/features/uploads/uploads.feature
@@ -157,6 +157,8 @@ Feature: API Resources which can have files uploaded
     And the response should be the resource "dummy_uploadable"
     And the JSON should be valid according to the schema "features/assets/schema/uploadable_has_files_with_imagine.schema.json"
     And the JSON node "_metadata.mediaObjects.file[0].contentUrl" should be a valid download link for the resource "dummy_uploadable"
+    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
   # DELETE
 
@@ -198,6 +200,8 @@ Feature: API Resources which can have files uploaded
       | 1970-11-11T23:59:59+00:00  |
     Then the response status code should be 200
     And the JSON node "componentPositions[0]" should exist
+    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.png$/"
+    And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
   @loginAdmin
   Scenario Outline: When I upload a new file to a publishable uploadable, the new draft should not have a component position and the original image should still exist
@@ -234,6 +238,49 @@ Feature: API Resources which can have files uploaded
       | key  | value      |
       | file | @image.svg |
     Then the response status code should be 201
+
+  # Publishing a draft that has a published resource runs the draft->published merge
+  # (PublishableEventListener::mergeDraftIntoPublished), which deletes the published resource's own
+  # file from the filestore before copying the draft's fields over it. Asserting the filename column
+  # is not enough - the download link step only compares a URL built from the IRI, and the schema only
+  # proves filename is non-null. These scenarios assert the stored object itself survives the merge.
+
+  @loginAdmin
+  Scenario: When I upload a file to an existing draft and then publish it, the published resource keeps the uploaded file
+    Given there is a DummyUploadableAndPublishable with a draft
+    And I add "Content-Type" header equal to "multipart/form-data"
+    When I send a "POST" request to the resource "dummy_uploadable_draft" and the postfix "/upload" with parameters:
+      | key  | value      |
+      | file | @image.svg |
+    Then the response status code should be 201
+    And I add "Content-Type" header equal to "application/merge-patch+json"
+    And I send a "PATCH" request to the resource "dummy_uploadable_draft" with data:
+      | publishedAt               |
+      | 1970-11-11T23:59:59+00:00 |
+    Then the response status code should be 200
+    And the response should be the resource "dummy_uploadable"
+    And the JSON node "_metadata.publishable.published" should be true
+    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the file for the resource "dummy_uploadable" should exist in its configured filestore
+
+  # A draft that was never published has no publishedResource, so checkMergeDraftIntoPublished returns
+  # early - no merge and no file deletion - and the resource keeps its own IRI once published.
+  @loginAdmin
+  Scenario: When I upload a file to a draft that has never been published and then publish it, the file is kept
+    Given there is a draft DummyUploadableAndPublishable
+    And I add "Content-Type" header equal to "multipart/form-data"
+    When I send a "POST" request to the resource "dummy_uploadable_draft" and the postfix "/upload" with parameters:
+      | key  | value      |
+      | file | @image.svg |
+    Then the response status code should be 201
+    And I add "Content-Type" header equal to "application/merge-patch+json"
+    And I send a "PATCH" request to the resource "dummy_uploadable_draft" with data:
+      | publishedAt               |
+      | 1970-11-11T23:59:59+00:00 |
+    Then the response status code should be 200
+    And the JSON node "_metadata.publishable.published" should be true
+    And the resource "dummy_uploadable_draft" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the file for the resource "dummy_uploadable_draft" should exist in its configured filestore
 
   @loginUser
   Scenario: An uploadable field configured with urlGenerator public returns a direct public URL

--- a/features/uploads/uploads.feature
+++ b/features/uploads/uploads.feature
@@ -157,7 +157,7 @@ Feature: API Resources which can have files uploaded
     And the response should be the resource "dummy_uploadable"
     And the JSON should be valid according to the schema "features/assets/schema/uploadable_has_files_with_imagine.schema.json"
     And the JSON node "_metadata.mediaObjects.file[0].contentUrl" should be a valid download link for the resource "dummy_uploadable"
-    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the resource "dummy_uploadable" should have a filename matching "#^components/image-[0-9a-f]{8}\.svg$#"
     And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
   # DELETE
@@ -200,7 +200,7 @@ Feature: API Resources which can have files uploaded
       | 1970-11-11T23:59:59+00:00  |
     Then the response status code should be 200
     And the JSON node "componentPositions[0]" should exist
-    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.png$/"
+    And the resource "dummy_uploadable" should have a filename matching "#^components/image-[0-9a-f]{8}\.png$#"
     And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
   @loginAdmin
@@ -260,7 +260,7 @@ Feature: API Resources which can have files uploaded
     Then the response status code should be 200
     And the response should be the resource "dummy_uploadable"
     And the JSON node "_metadata.publishable.published" should be true
-    And the resource "dummy_uploadable" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the resource "dummy_uploadable" should have a filename matching "#^components/image-[0-9a-f]{8}\.svg$#"
     And the file for the resource "dummy_uploadable" should exist in its configured filestore
 
   # A draft that was never published has no publishedResource, so checkMergeDraftIntoPublished returns
@@ -279,7 +279,7 @@ Feature: API Resources which can have files uploaded
       | 1970-11-11T23:59:59+00:00 |
     Then the response status code should be 200
     And the JSON node "_metadata.publishable.published" should be true
-    And the resource "dummy_uploadable_draft" should have a filename matching "/^image-[^\/]+\.svg$/"
+    And the resource "dummy_uploadable_draft" should have a filename matching "#^components/image-[0-9a-f]{8}\.svg$#"
     And the file for the resource "dummy_uploadable_draft" should exist in its configured filestore
 
   @loginUser

--- a/src/EventListener/Api/PublishableEventListener.php
+++ b/src/EventListener/Api/PublishableEventListener.php
@@ -243,6 +243,10 @@ final class PublishableEventListener
             }
         }
 
+        // The write continues against the published resource from here, so any field the payload
+        // cleared on the draft must stay cleared — the marker is keyed on the resource it was set on.
+        $this->uploadableFileManager->transferDeletedFields($draftResource, $publishedResource);
+
         $entityManager = $this->getEntityManager($draftResource);
         $entityManager->remove($draftResource);
 

--- a/src/EventListener/Api/PublishableEventListener.php
+++ b/src/EventListener/Api/PublishableEventListener.php
@@ -224,10 +224,10 @@ final class PublishableEventListener
         $publishedReflection = new \ReflectionClass($publishedResource);
         $properties = $publishedReflection->getProperties();
 
-        try {
-            $this->uploadableFileManager->deleteFiles($publishedResource);
-        } catch (\InvalidArgumentException $e) {
-        }
+        // Capture what the published resource points at before the copy overwrites it. Deleting up
+        // front destroys the file with nothing yet known to have succeeded, and destroys it even
+        // when the draft carries the same path.
+        $previousFilePaths = $this->uploadableFileManager->getStoredFilePaths($publishedResource);
 
         foreach ($properties as $property) {
             //            $property->setAccessible(true);
@@ -246,6 +246,10 @@ final class PublishableEventListener
         // The write continues against the published resource from here, so any field the payload
         // cleared on the draft must stay cleared — the marker is keyed on the resource it was set on.
         $this->uploadableFileManager->transferDeletedFields($draftResource, $publishedResource);
+
+        // The published resource now holds the draft's paths: delete only the files it has stopped
+        // referencing, never one it still points at.
+        $this->uploadableFileManager->deleteOrphanedFiles($publishedResource, $previousFilePaths);
 
         $entityManager = $this->getEntityManager($draftResource);
         $entityManager->remove($draftResource);

--- a/src/Helper/Uploadable/UploadableFileManager.php
+++ b/src/Helper/Uploadable/UploadableFileManager.php
@@ -11,7 +11,6 @@
 
 namespace Silverback\ApiComponentsBundle\Helper\Uploadable;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Liip\ImagineBundle\Service\FilterService;
@@ -45,7 +44,19 @@ class UploadableFileManager
     private FileInfoCacheManager $fileInfoCacheManager;
     private ?CacheManager $imagineCacheManager;
     private ?FilterService $filterService;
-    private ArrayCollection $deletedFields;
+
+    /**
+     * Storage properties the request payload explicitly cleared, keyed by the resource they were
+     * cleared on. Keyed by object because the marker belongs to a resource, not to a property name:
+     * `filename` is the default storage property for every UploadableField, so a marker held as a
+     * bare name would apply to any resource written afterwards. A WeakMap rather than a plain map so
+     * entries die with the objects — nothing accumulates on this shared service between requests
+     * under a long-running runtime (FrankenPHP worker mode, RoadRunner), where a leaked marker would
+     * silently delete the file of every later write that carries no new file, a publish being one.
+     *
+     * @var \WeakMap<object, list<string>>
+     */
+    private \WeakMap $deletedFields;
 
     public function __construct(
         ManagerRegistry $registry,
@@ -63,12 +74,33 @@ class UploadableFileManager
         $this->fileInfoCacheManager = $fileInfoCacheManager;
         $this->imagineCacheManager = $imagineCacheManager;
         $this->filterService = $filterService;
-        $this->deletedFields = new ArrayCollection();
+        $this->deletedFields = new \WeakMap();
     }
 
-    public function addDeletedField($field): void
+    public function addDeletedField(object $object, string $field): void
     {
-        $this->deletedFields->add($field);
+        $fields = $this->deletedFields[$object] ?? [];
+        if (!\in_array($field, $fields, true)) {
+            $fields[] = $field;
+        }
+        $this->deletedFields[$object] = $fields;
+    }
+
+    /**
+     * Hands a resource's deleted-field markers to the resource replacing it. Publishing a draft
+     * merges it into the published resource and continues the write against that instance, so a
+     * request that clears a file and publishes in one go must carry the marker across with it.
+     */
+    public function transferDeletedFields(object $from, object $to): void
+    {
+        foreach ($this->deletedFields[$from] ?? [] as $field) {
+            $this->addDeletedField($to, $field);
+        }
+    }
+
+    private function isFieldDeleted(object $object, string $field): bool
+    {
+        return \in_array($field, $this->deletedFields[$object] ?? [], true);
     }
 
     public function processClonedUploadable(object $oldObject, object $newObject): object
@@ -147,7 +179,7 @@ class UploadableFileManager
             $file = $propertyAccessor->getValue($object, $fileProperty);
             if (!$file) {
                 // so we need to know if it was a deleted field from the denormalizer
-                if ($this->deletedFields->contains($fieldConfiguration->property)) {
+                if ($this->isFieldDeleted($object, $fieldConfiguration->property)) {
                     $this->deleteFileForField($object, $classMetadata, $fieldConfiguration);
                     $classMetadata->setFieldValue($object, $fieldConfiguration->property, null);
                 }

--- a/src/Helper/Uploadable/UploadableFileManager.php
+++ b/src/Helper/Uploadable/UploadableFileManager.php
@@ -300,6 +300,55 @@ class UploadableFileManager
         }
     }
 
+    /**
+     * The stored path of each uploadable field, keyed by storage property. Empty for a resource that
+     * is not uploadable, so callers need no is-uploadable dance before taking a snapshot.
+     *
+     * @return array<string, string|null>
+     */
+    public function getStoredFilePaths(object $object): array
+    {
+        if (!$this->annotationReader->isConfigured($object)) {
+            return [];
+        }
+
+        $classMetadata = $this->getClassMetadata($object);
+
+        $paths = [];
+        foreach ($this->annotationReader->getConfiguredProperties($object, true) as $fieldConfiguration) {
+            $paths[$fieldConfiguration->property] = $classMetadata->getFieldValue($object, $fieldConfiguration->property);
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Deletes the files a resource has stopped referencing, given the paths it held before a write.
+     *
+     * A path it still points at is never deleted: replacing a file must not delete the file that
+     * replaced it, and a field the write left alone must keep its file. Deleting up front instead —
+     * before the new values are in place — destroys the file with nothing yet known to have
+     * succeeded, and destroys it even when the incoming value is the very same path.
+     *
+     * @param array<string, string|null> $previousPaths from getStoredFilePaths(), taken before the write
+     */
+    public function deleteOrphanedFiles(object $object, array $previousPaths): void
+    {
+        if (!$this->annotationReader->isConfigured($object)) {
+            return;
+        }
+
+        $classMetadata = $this->getClassMetadata($object);
+
+        foreach ($this->annotationReader->getConfiguredProperties($object, true) as $fieldConfiguration) {
+            $previousFilepath = $previousPaths[$fieldConfiguration->property] ?? null;
+            if (!$previousFilepath || $previousFilepath === $classMetadata->getFieldValue($object, $fieldConfiguration->property)) {
+                continue;
+            }
+            $this->removeFilepathValue($fieldConfiguration, $previousFilepath);
+        }
+    }
+
     public function getFileResponse(object $object, string $property, bool $forceDownload = false): Response
     {
         try {
@@ -339,16 +388,24 @@ class UploadableFileManager
 
     private function removeFilepath(object $object, UploadableField $fieldConfiguration): void
     {
-        $classMetadata = $this->getClassMetadata($object);
+        $currentFilepath = $this->getClassMetadata($object)->getFieldValue($object, $fieldConfiguration->property);
 
+        $this->removeFilepathValue($fieldConfiguration, $currentFilepath);
+    }
+
+    /**
+     * Takes the path rather than reading it off the resource, so a path the resource has already
+     * stopped referencing can still be cleaned up.
+     */
+    private function removeFilepathValue(UploadableField $fieldConfiguration, string $filepath): void
+    {
         $filesystem = $this->filesystemProvider->getFilesystem($fieldConfiguration->adapter);
-        $currentFilepath = $classMetadata->getFieldValue($object, $fieldConfiguration->property);
-        $this->fileInfoCacheManager->deleteCaches([$currentFilepath], [null]);
+        $this->fileInfoCacheManager->deleteCaches([$filepath], [null]);
         if ($this->imagineCacheManager) {
-            $this->imagineCacheManager->remove([$currentFilepath], null);
+            $this->imagineCacheManager->remove([$filepath], null);
         }
-        if ($filesystem->fileExists($currentFilepath)) {
-            $filesystem->delete($currentFilepath);
+        if ($filesystem->fileExists($filepath)) {
+            $filesystem->delete($filepath);
         }
     }
 

--- a/src/Helper/Uploadable/UploadableFileManager.php
+++ b/src/Helper/Uploadable/UploadableFileManager.php
@@ -352,6 +352,12 @@ class UploadableFileManager
         }
     }
 
+    /**
+     * Copies a resource's stored file so a clone (a publishable draft) owns its own object. The copy
+     * is written beside the original — the field's prefix is part of the stored path, so a copy built
+     * from the basename alone would escape it — under the same tokenised naming as every other stored
+     * file, which also guarantees it cannot collide with an existing object.
+     */
     private function copyFilepath(object $object, UploadableField $fieldConfiguration): ?string
     {
         $classMetadata = $this->getClassMetadata($object);
@@ -359,18 +365,25 @@ class UploadableFileManager
         $filesystem = $this->filesystemProvider->getFilesystem($fieldConfiguration->adapter);
         $currentFilepath = $classMetadata->getFieldValue($object, $fieldConfiguration->property);
         if (!$filesystem->fileExists($currentFilepath)) {
-            return null;
+            // The stored object is gone. Keep the clone pointing at the same path rather than nulling
+            // it: a missing file is a recoverable storage problem, whereas nulling discards the only
+            // record of what the file was and, on the next publish, copies that null over the
+            // published resource's own path.
+            return $currentFilepath;
         }
+
         $pathInfo = pathinfo($currentFilepath);
-        $basename = $pathInfo['filename'];
-        $extension = $pathInfo['extension'] ?? null;
-        if (!empty($extension)) {
-            $extension = \sprintf('.%s', $extension);
-        }
-        $num = 1;
-        while ($filesystem->fileExists($newFilepath = \sprintf('%s_%d%s', $basename, $num, $extension))) {
-            ++$num;
-        }
+        $directory = '.' === $pathInfo['dirname'] ? '' : $pathInfo['dirname'] . '/';
+
+        // Strip the token off an already-tokenised name before adding a new one, so a resource that
+        // is drafted and published repeatedly does not accumulate a token per cycle.
+        $stem = (string) preg_replace('/-[0-9a-f]{8}$/', '', $pathInfo['filename']);
+        $extension = isset($pathInfo['extension']) ? '.' . $pathInfo['extension'] : '';
+
+        do {
+            $newFilepath = $directory . $this->tokeniseFilename($stem . $extension);
+        } while ($filesystem->fileExists($newFilepath));
+
         $filesystem->copy($currentFilepath, $newFilepath);
 
         return $newFilepath;

--- a/src/Mercure/MercureResourcePublisher.php
+++ b/src/Mercure/MercureResourcePublisher.php
@@ -96,6 +96,9 @@ class MercureResourcePublisher implements SerializerAwareInterface, ResourceChan
         $this->createdObjects = new \SplObjectStorage();
         $this->updatedObjects = new \SplObjectStorage();
         $this->deletedObjects = new \SplObjectStorage();
+        // A request that dies inside propagate() would otherwise leave the re-entrancy guard raised,
+        // silently suppressing every publish for the rest of a worker's life.
+        $this->isPropagating = false;
     }
 
     public function add(object $item, ?string $type = null): void

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -859,7 +859,10 @@ return static function (ContainerConfigurator $configurator) {
         ->tag('kernel.event_listener', ['event' => Events::AUTHENTICATION_SUCCESS, 'method' => 'onJWTAuthenticationSuccess'])
         ->tag('kernel.event_listener', ['event' => Events::JWT_CREATED, 'method' => 'onJWTCreated'])
         ->tag('kernel.event_listener', ['event' => JWTRefreshedEvent::class, 'method' => 'onJWTRefreshed'])
-        ->tag('kernel.event_listener', ['event' => KernelEvents::RESPONSE, 'method' => 'onKernelResponse']);
+        ->tag('kernel.event_listener', ['event' => KernelEvents::RESPONSE, 'method' => 'onKernelResponse'])
+        // Holds the JWT to write as a cookie. onKernelResponse consumes it, but a request that never
+        // reaches that listener must not leave one user's token to be written for the next.
+        ->tag('kernel.reset', ['method' => 'reset']);
     $services->alias(JWTEventListener::class, 'silverback.security.jwt_event_listener');
 
     $services
@@ -1877,7 +1880,10 @@ return static function (ContainerConfigurator $configurator) {
 
     $services
         ->set('silverback.api_components.data_collector.data')
-        ->class(CwaCollectorData::class);
+        ->class(CwaCollectorData::class)
+        // Gathers profiler panel data across the request. CwaDataCollector::reset() also clears it,
+        // but the tag makes the guarantee independent of the profiler being enabled.
+        ->tag('kernel.reset', ['method' => 'reset']);
     $services->alias(CwaCollectorData::class, 'silverback.api_components.data_collector.data');
 
     $services

--- a/src/Resources/config/services_doctrine_orm_http_cache_purger.php
+++ b/src/Resources/config/services_doctrine_orm_http_cache_purger.php
@@ -31,6 +31,9 @@ return static function (ContainerConfigurator $configurator) {
             new Reference('api_platform.http_cache.purger', ContainerInterface::NULL_ON_INVALID_REFERENCE),
             new Reference(CwaCollectorData::class),
         ])
-        ->tag('silverback_api_components.resource_changed_propagator');
+        ->tag('silverback_api_components.resource_changed_propagator')
+        // Queues IRIs to invalidate during the request. Tagged explicitly rather than relying on
+        // autoconfiguration, which an application may disable — see ServicesResetterTest.
+        ->tag('kernel.reset', ['method' => 'reset']);
     $services->alias(HttpCachePurger::class, 'silverback.api_components.http_cache.purger');
 };

--- a/src/Resources/config/services_doctrine_orm_mercure_publisher.php
+++ b/src/Resources/config/services_doctrine_orm_mercure_publisher.php
@@ -43,6 +43,9 @@ return static function (ContainerConfigurator $configurator) {
             new Reference(CwaCollectorData::class),
         ])
         ->call('setSerializer', [new Reference('serializer')])
-        ->tag('silverback_api_components.resource_changed_propagator');
+        ->tag('silverback_api_components.resource_changed_propagator')
+        // Queues objects changed during the request. Tagged explicitly rather than relying on
+        // autoconfiguration, which an application may disable — see ServicesResetterTest.
+        ->tag('kernel.reset', ['method' => 'reset']);
     $services->alias(MercureResourcePublisher::class, 'silverback.api_components.mercure.resource_publisher');
 };

--- a/src/Serializer/Normalizer/UploadableNormalizer.php
+++ b/src/Serializer/Normalizer/UploadableNormalizer.php
@@ -65,7 +65,10 @@ final class UploadableNormalizer implements DenormalizerInterface, DenormalizerA
         return !isset($context[self::ALREADY_CALLED]) && $this->annotationReader->isConfigured($type);
     }
 
-    private function findConfiguredFields(iterable $data, string $type): iterable
+    /**
+     * @param list<string> $deletedProperties storage properties the payload explicitly cleared
+     */
+    private function findConfiguredFields(iterable $data, string $type, array &$deletedProperties): iterable
     {
         foreach ($data as $fieldName => $value) {
             try {
@@ -83,7 +86,7 @@ final class UploadableNormalizer implements DenormalizerInterface, DenormalizerA
             // Value is empty: set it to null. Might be blank string
             if (empty($value)) {
                 $fieldConfig = $this->annotationReader->getPropertyConfiguration($reflectionProperty);
-                $this->uploadableFileManager->addDeletedField($fieldConfig->property);
+                $deletedProperties[] = $fieldConfig->property;
                 $data[$fieldName] = null;
                 continue;
             }
@@ -106,11 +109,25 @@ final class UploadableNormalizer implements DenormalizerInterface, DenormalizerA
     {
         $context[self::ALREADY_CALLED] = true;
 
+        $deletedProperties = [];
         if (is_iterable($data)) {
-            $data = $this->findConfiguredFields($data, $type);
+            $data = $this->findConfiguredFields($data, $type, $deletedProperties);
         }
 
-        return $this->denormalizer->denormalize($data, $type, $format, $context);
+        $object = $this->denormalizer->denormalize($data, $type, $format, $context);
+
+        // Register the cleared fields against the resource the denormalizer produced, not against the
+        // property name alone — `filename` is the default storage property for every UploadableField,
+        // so a name-only marker applies to whatever is written next. For a published publishable
+        // resource the object here is the draft created during denormalization, so clearing a file
+        // clears it on the draft and leaves the published resource's file alone.
+        if (\is_object($object)) {
+            foreach ($deletedProperties as $property) {
+                $this->uploadableFileManager->addDeletedField($object, $property);
+            }
+        }
+
+        return $object;
     }
 
     public function supportsNormalization($data, $format = null, array $context = []): bool

--- a/tests/DependencyInjection/ServicesResetterTest.php
+++ b/tests/DependencyInjection/ServicesResetterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\DependencyInjection;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+
+/**
+ * Under a long-running runtime — FrankenPHP worker mode, RoadRunner — one kernel serves many
+ * requests, so a shared service holding per-request state carries it into the next request unless
+ * the framework resets it. That is not a theoretical risk here: a marker left on
+ * UploadableFileManager between requests silently deleted uploaded files on publish.
+ *
+ * `ResetInterface` alone does nothing — a service is only reset if it carries the `kernel.reset`
+ * tag. Autoconfiguration adds that tag, but this is a bundle: applications may disable
+ * autoconfiguration, and several of the bundle's own definitions already opt out of it. So the tag
+ * must be explicit on every service that holds request-scoped state.
+ *
+ * @author Daniel West <daniel@silverback.is>
+ */
+class ServicesResetterTest extends KernelTestCase
+{
+    /**
+     * Services that accumulate state during a request and must be emptied between requests.
+     *
+     * Add to this list whenever a bundle service gains mutable per-request state — or, better,
+     * scope the state so it cannot outlive its request (UploadableFileManager keys its markers in a
+     * WeakMap by the resource they belong to, so it needs no reset at all).
+     */
+    private const MUST_BE_RESETTABLE = [
+        // Queues objects changed during the request, flushed on propagate()
+        'silverback.api_components.mercure.resource_publisher',
+        // Same, for cache invalidation
+        'silverback.api_components.http_cache.purger',
+        // Profiler panel data gathered across the request
+        'silverback.api_components.data_collector.data',
+        // Holds the JWT to be written as a cookie on the response
+        'silverback.security.jwt_event_listener',
+    ];
+
+    public function test_bundle_services_holding_request_state_are_registered_with_the_services_resetter(): void
+    {
+        self::bootKernel();
+
+        $resetter = self::getContainer()->get('services_resetter');
+        self::assertInstanceOf(ServicesResetter::class, $resetter);
+
+        $resetMethods = (new \ReflectionProperty(ServicesResetter::class, 'resetMethods'))->getValue($resetter);
+
+        foreach (self::MUST_BE_RESETTABLE as $serviceId) {
+            self::assertArrayHasKey(
+                $serviceId,
+                $resetMethods,
+                \sprintf('"%s" holds per-request state but is not tagged kernel.reset, so it would carry that state into the next request in worker mode.', $serviceId)
+            );
+        }
+
+        // Booting a kernel in debug registers Symfony's ErrorHandler, which PHPUnit reports as a
+        // risky test. It cannot be handed back from here (restore_exception_handler does not clear
+        // it), and risky is not a failure, so the notice is accepted.
+        self::ensureKernelShutdown();
+    }
+}

--- a/tests/Functional/TestBundle/Entity/DummyUploadableAndPublishable.php
+++ b/tests/Functional/TestBundle/Entity/DummyUploadableAndPublishable.php
@@ -31,6 +31,8 @@ class DummyUploadableAndPublishable extends AbstractComponent
     use PublishableTrait;
     use UploadableTrait;
 
-    #[Silverback\UploadableField(adapter: 'local')]
+    // A prefix so the draft-clone and publish-merge paths are exercised against a stored path that
+    // has a directory to preserve, not just a bare basename.
+    #[Silverback\UploadableField(adapter: 'local', prefix: 'components/')]
     public ?File $file = null;
 }

--- a/tests/Helper/Uploadable/UploadableFileManagerTest.php
+++ b/tests/Helper/Uploadable/UploadableFileManagerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\Helper\Uploadable;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use League\Flysystem\Filesystem;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
+use PHPUnit\Framework\TestCase;
+use Silverback\ApiComponentsBundle\Annotation as Silverback;
+use Silverback\ApiComponentsBundle\AttributeReader\UploadableAttributeReader;
+use Silverback\ApiComponentsBundle\Flysystem\FilesystemProvider;
+use Silverback\ApiComponentsBundle\Helper\Uploadable\FileInfoCacheManager;
+use Silverback\ApiComponentsBundle\Helper\Uploadable\UploadableFileManager;
+use Silverback\ApiComponentsBundle\Imagine\FlysystemDataLoader;
+use Symfony\Component\HttpFoundation\File\File;
+
+/**
+ * Named stub so the attribute reader has a real class to read UploadableField configuration from.
+ * Both fields use the default storage property name, `filename`, as every UploadableField does
+ * unless `property:` is set — which is what makes a marker keyed on the name alone ambiguous.
+ */
+#[Silverback\Uploadable]
+class _LeakTestUploadable
+{
+    #[Silverback\UploadableField(adapter: 'local')]
+    public ?File $file = null;
+
+    public ?string $filename = null;
+}
+
+/**
+ * @author Daniel West <daniel@silverback.is>
+ */
+class UploadableFileManagerTest extends TestCase
+{
+    /**
+     * A "delete this file" marker belongs to the resource being written, not to the storage property
+     * name. It used to be recorded on this shared service as the bare string 'filename' — the default
+     * storage property of every UploadableField — and never cleared, so any later write carrying no
+     * new file inherited it. Under a long-running runtime (FrankenPHP worker mode) that outlived the
+     * request too: one admin file deletion poisoned every subsequent publish served by that worker,
+     * silently deleting an unrelated resource's file and nulling its path.
+     */
+    public function test_a_deleted_field_marked_on_one_object_does_not_delete_another_objects_file(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('image-aaa.png', 'file of the resource whose file is being cleared');
+        $filesystem->write('image-bbb.png', 'file of an unrelated resource');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $clearedResource = new _LeakTestUploadable();
+        $clearedResource->filename = 'image-aaa.png';
+
+        $unrelatedResource = new _LeakTestUploadable();
+        $unrelatedResource->filename = 'image-bbb.png';
+
+        // The admin clears a file: PATCH {"file": null}, which the denormalizer records as a deleted
+        // field against the resource it is denormalizing before the file manager acts on it.
+        $manager->addDeletedField($clearedResource, 'filename');
+        $manager->persistFiles($clearedResource);
+
+        self::assertFalse($filesystem->fileExists('image-aaa.png'));
+        self::assertNull($clearedResource->filename);
+
+        // A later write carrying no new file — a publish PATCH is exactly this — must not inherit
+        // the marker, whether it happens in the same request or later in the same worker process.
+        $manager->persistFiles($unrelatedResource);
+
+        self::assertTrue(
+            $filesystem->fileExists('image-bbb.png'),
+            'An unrelated resource\'s file was deleted by a marker left over from an earlier write.'
+        );
+        self::assertSame('image-bbb.png', $unrelatedResource->filename);
+    }
+
+    /**
+     * The counterpart: scoping the marker must not stop it working for the resource it was set on.
+     */
+    public function test_a_deleted_field_still_removes_the_file_for_the_object_it_was_marked_on(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('image-aaa.png', 'file to be cleared');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $resource = new _LeakTestUploadable();
+        $resource->filename = 'image-aaa.png';
+
+        $manager->addDeletedField($resource, 'filename');
+        $manager->persistFiles($resource);
+
+        self::assertFalse($filesystem->fileExists('image-aaa.png'));
+        self::assertNull($resource->filename);
+    }
+
+    /**
+     * Without any marker, a write that carries no new file leaves the stored file alone.
+     */
+    public function test_a_write_with_no_new_file_and_no_marker_leaves_the_stored_file_alone(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('image-aaa.png', 'file that must survive');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $resource = new _LeakTestUploadable();
+        $resource->filename = 'image-aaa.png';
+
+        $manager->persistFiles($resource);
+
+        self::assertTrue($filesystem->fileExists('image-aaa.png'));
+        self::assertSame('image-aaa.png', $resource->filename);
+    }
+
+    /**
+     * Publishing a draft merges it into the published resource and the write continues against that
+     * instance, so a request that clears a file and publishes in one go must still clear the file.
+     */
+    public function test_a_deleted_field_marker_follows_a_draft_when_it_is_merged_into_its_published_resource(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('image-aaa.png', 'file the merged resource carries');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $draft = new _LeakTestUploadable();
+        $published = new _LeakTestUploadable();
+        $published->filename = 'image-aaa.png';
+
+        $manager->addDeletedField($draft, 'filename');
+        $manager->transferDeletedFields($draft, $published);
+        $manager->persistFiles($published);
+
+        self::assertFalse($filesystem->fileExists('image-aaa.png'));
+        self::assertNull($published->filename);
+    }
+
+    private function createFileManager(Filesystem $filesystem): UploadableFileManager
+    {
+        $classMetadata = $this->createStub(ClassMetadata::class);
+        $classMetadata
+            ->method('getFieldValue')
+            ->willReturnCallback(static fn (object $entity, string $field): mixed => $entity->{$field});
+        $classMetadata
+            ->method('setFieldValue')
+            ->willReturnCallback(static function (object $entity, string $field, mixed $value): void {
+                $entity->{$field} = $value;
+            });
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getClassMetadata')->willReturn($classMetadata);
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($entityManager);
+
+        $filesystemProvider = $this->createStub(FilesystemProvider::class);
+        $filesystemProvider->method('getFilesystem')->willReturn($filesystem);
+
+        return new UploadableFileManager(
+            $registry,
+            new UploadableAttributeReader($registry, false),
+            $filesystemProvider,
+            $this->createStub(FlysystemDataLoader::class),
+            $this->createStub(FileInfoCacheManager::class),
+            null,
+            null
+        );
+    }
+}

--- a/tests/Helper/Uploadable/UploadableFileManagerTest.php
+++ b/tests/Helper/Uploadable/UploadableFileManagerTest.php
@@ -52,10 +52,103 @@ class _PrefixedTestUploadable
 }
 
 /**
+ * Named stub for the not-uploadable path — no `#[Uploadable]` attribute.
+ */
+class _NotUploadableStub
+{
+    public ?string $filename = null;
+}
+
+/**
  * @author Daniel West <daniel@silverback.is>
  */
 class UploadableFileManagerTest extends TestCase
 {
+    /**
+     * Publishing a draft replaces the published resource's stored path with the draft's. The file it
+     * has stopped referencing is then orphaned and should go.
+     */
+    public function test_orphaned_file_deletion_removes_a_path_the_resource_no_longer_references(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('components/old-aaaaaaaa.png', 'the replaced file');
+        $filesystem->write('components/new-bbbbbbbb.png', 'the replacement');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $resource = new _LeakTestUploadable();
+        $resource->filename = 'components/old-aaaaaaaa.png';
+
+        $previousPaths = $manager->getStoredFilePaths($resource);
+        self::assertSame(['filename' => 'components/old-aaaaaaaa.png'], $previousPaths);
+
+        $resource->filename = 'components/new-bbbbbbbb.png';
+        $manager->deleteOrphanedFiles($resource, $previousPaths);
+
+        self::assertFalse($filesystem->fileExists('components/old-aaaaaaaa.png'));
+        self::assertTrue($filesystem->fileExists('components/new-bbbbbbbb.png'));
+    }
+
+    /**
+     * The case the old delete-then-copy order got wrong: when the draft carries the same stored path
+     * as the published resource, deleting "the published resource's file" destroys the very file the
+     * resource still points at.
+     */
+    public function test_orphaned_file_deletion_keeps_a_path_the_resource_still_references(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('components/kept-aaaaaaaa.png', 'the file both resources point at');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $resource = new _LeakTestUploadable();
+        $resource->filename = 'components/kept-aaaaaaaa.png';
+
+        $previousPaths = $manager->getStoredFilePaths($resource);
+        $manager->deleteOrphanedFiles($resource, $previousPaths);
+
+        self::assertTrue($filesystem->fileExists('components/kept-aaaaaaaa.png'));
+        self::assertSame('components/kept-aaaaaaaa.png', $resource->filename);
+    }
+
+    /**
+     * Publishing a draft that genuinely has no file still removes the published resource's file.
+     */
+    public function test_orphaned_file_deletion_removes_the_previous_file_when_the_field_is_now_empty(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('components/old-aaaaaaaa.png', 'the file being dropped');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $resource = new _LeakTestUploadable();
+        $resource->filename = 'components/old-aaaaaaaa.png';
+
+        $previousPaths = $manager->getStoredFilePaths($resource);
+
+        $resource->filename = null;
+        $manager->deleteOrphanedFiles($resource, $previousPaths);
+
+        self::assertFalse($filesystem->fileExists('components/old-aaaaaaaa.png'));
+    }
+
+    /**
+     * Callers should not have to ask whether a resource is uploadable before using either method.
+     */
+    public function test_orphaned_file_deletion_is_a_no_op_for_a_resource_that_is_not_uploadable(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('components/old-aaaaaaaa.png', 'nothing to do with this resource');
+
+        $manager = $this->createFileManager($filesystem);
+
+        self::assertSame([], $manager->getStoredFilePaths(new _NotUploadableStub()));
+
+        $manager->deleteOrphanedFiles(new _NotUploadableStub(), ['filename' => 'components/old-aaaaaaaa.png']);
+
+        self::assertTrue($filesystem->fileExists('components/old-aaaaaaaa.png'));
+    }
+
     /**
      * Creating a draft of a publishable uploadable clones the stored file so the two resources own
      * their files independently. The copy belongs beside the original — the field's prefix is part of

--- a/tests/Helper/Uploadable/UploadableFileManagerTest.php
+++ b/tests/Helper/Uploadable/UploadableFileManagerTest.php
@@ -40,10 +40,66 @@ class _LeakTestUploadable
 }
 
 /**
+ * Named stub for the clone path: a field with a `prefix:` so the copy has a directory to preserve.
+ */
+#[Silverback\Uploadable]
+class _PrefixedTestUploadable
+{
+    #[Silverback\UploadableField(adapter: 'local', prefix: 'documents/')]
+    public ?File $file = null;
+
+    public ?string $filename = null;
+}
+
+/**
  * @author Daniel West <daniel@silverback.is>
  */
 class UploadableFileManagerTest extends TestCase
 {
+    /**
+     * Creating a draft of a publishable uploadable clones the stored file so the two resources own
+     * their files independently. The copy belongs beside the original — the field's prefix is part of
+     * the stored path — and carries a unique token like every other stored name.
+     */
+    public function test_cloning_an_uploadable_copies_the_file_alongside_the_original_with_a_tokenised_name(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+        $filesystem->write('documents/report-aaaaaaaa.pdf', 'the original');
+
+        $manager = $this->createFileManager($filesystem);
+
+        $published = new _PrefixedTestUploadable();
+        $published->filename = 'documents/report-aaaaaaaa.pdf';
+        $draft = new _PrefixedTestUploadable();
+
+        $manager->processClonedUploadable($published, $draft);
+
+        self::assertMatchesRegularExpression('#^documents/report-[0-9a-f]{8}\.pdf$#', (string) $draft->filename);
+        self::assertNotSame($published->filename, $draft->filename);
+        self::assertTrue($filesystem->fileExists((string) $draft->filename));
+        self::assertTrue($filesystem->fileExists($published->filename), 'The clone must not disturb the original.');
+    }
+
+    /**
+     * A stored file missing from the filestore is a recoverable storage problem. Nulling the clone's
+     * path would discard the only record of what the file was, and publishing that draft would then
+     * copy the null onto the published resource — turning a missing object into permanent loss.
+     */
+    public function test_cloning_an_uploadable_whose_stored_file_is_missing_keeps_the_original_path(): void
+    {
+        $filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+
+        $manager = $this->createFileManager($filesystem);
+
+        $published = new _PrefixedTestUploadable();
+        $published->filename = 'documents/gone-aaaaaaaa.pdf';
+        $draft = new _PrefixedTestUploadable();
+
+        $manager->processClonedUploadable($published, $draft);
+
+        self::assertSame('documents/gone-aaaaaaaa.pdf', $draft->filename);
+    }
+
     /**
      * A "delete this file" marker belongs to the resource being written, not to the storage property
      * name. It used to be recorded on this shared service as the bare string 'filename' — the default


### PR DESCRIPTION
Files uploaded to a draft were vanishing when the draft was published — the component surviving with its text intact, only the file gone, intermittently and never in dev. Diagnosing that turned up four defects; the first is the cause, the rest are the same class of problem found alongside it.

Closes #205, #206, #207, #208.

## The cause — #205

`UploadableNormalizer` records a `PATCH {"file": null}` as a "deleted field" so `persistFiles()` can tell *no file submitted* from *the file was explicitly removed*. That marker was a bare storage-property name on the shared `UploadableFileManager`, never cleared. `filename` is the default storage property of every `UploadableField`, so it matched whatever was written next — and in FrankenPHP worker mode it outlived the request. One admin file deletion poisoned every later write in that worker carrying no new file. A publish is `PATCH {publishedAt}`, exactly that.

Markers now live in a `\WeakMap` keyed by the resource they belong to. `addDeletedField()` changes signature (public, internal-only caller).

## #206 — `copyFilepath()`

Dropped the field's `prefix` from a draft's copy, skipped tokenised naming, and nulled the clone when the source was missing — turning a recoverable storage problem into permanent loss on the next publish. It now copies beside the original, tokenised, and keeps the original path when the source is gone.

## #207 — merge ordering

The publish merge deleted the published resource's file *before* the copy, in a swallowed `catch`, and deleted it even when the draft carried the same path. It now snapshots paths, copies, then deletes only what the resource has stopped referencing.

## #208 — `kernel.reset`

No bundle service was tagged, so `ResetInterface` implementations were never reset — autoconfiguration can't be relied on in a bundle. Four services tagged; `ServicesResetterTest` guards it.

## Testing

The leak, the two `copyFilepath` defects and the merge ordering were each reproduced as a failing test before being fixed — the merge scenario verified failing against the old ordering with `Expected file "components/image-ad8da666.png" to exist in adapter "local" but it does not`.

A gap this exposed: nothing asserted the *stored object* survived a publish. `should be a valid download link` only string-compares a URL built from the IRI, and the schemas only prove `filename` is non-null. Behat now checks the filestore on every merge scenario, and gained the publish-an-uploadable-draft scenarios that were missing entirely.

579 unit tests, 448 Behat scenarios, php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)