### PR TITLE
Fix mutation gate broken by risky ServicesResetterTest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,7 +642,9 @@ References: `src/Helper/Uploadable/UploadableFileManager.php` (`getStoredFilePat
 
 Tagged explicitly: `mercure.resource_publisher` and `http_cache.purger` (queue changed objects), `data_collector.data` (profiler panel data), `jwt_event_listener` (holds the JWT to write as a cookie). `MercureResourcePublisher::reset()` also lowers `isPropagating`, so a request dying inside `propagate()` cannot leave the re-entrancy guard raised and suppress every publish for the rest of a worker's life.
 
-`tests/DependencyInjection/ServicesResetterTest.php` asserts each is registered with the `services_resetter`. **Add to its list whenever a bundle service gains mutable per-request state** — or better, scope the state so it cannot outlive its request, as `UploadableFileManager` does with a `WeakMap`. (The test is reported Risky: booting a kernel in debug registers Symfony's ErrorHandler and it cannot be handed back. Risky is not a failure and `failOnRisky` is unset.)
+`tests/DependencyInjection/ServicesResetterTest.php` loads the config files into a bare `ContainerBuilder` and asserts the tag is on each **definition**. It deliberately does not boot a kernel: autoconfiguration would add the tag there and mask a missing one, so a booted-kernel test would assert the wrong thing. **Add to its list whenever a bundle service gains mutable per-request state** — or better, scope the state so it cannot outlive its request, as `UploadableFileManager` does with a `WeakMap`.
+
+> **Do not write kernel-booting tests casually.** Booting in debug registers Symfony's ErrorHandler, which PHPUnit reports as Risky, and **Infection's initial test run fails on Risky** — so a single risky test aborts the whole mutation gate in CI (`PHPUnit (Symfony 7.4)`, the coverage job) even though `failOnRisky` is unset for the normal suite. The first version of this test did exactly that and broke the build.
 
 ---
 

--- a/tests/DependencyInjection/ServicesResetterTest.php
+++ b/tests/DependencyInjection/ServicesResetterTest.php
@@ -11,8 +11,10 @@
 
 namespace Silverback\ApiComponentsBundle\Tests\DependencyInjection;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 /**
  * Under a long-running runtime — FrankenPHP worker mode, RoadRunner — one kernel serves many
@@ -23,50 +25,53 @@ use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
  * `ResetInterface` alone does nothing — a service is only reset if it carries the `kernel.reset`
  * tag. Autoconfiguration adds that tag, but this is a bundle: applications may disable
  * autoconfiguration, and several of the bundle's own definitions already opt out of it. So the tag
- * must be explicit on every service that holds request-scoped state.
+ * must be on the definition itself, which is what this asserts — the service definitions are read
+ * straight from the config files rather than from a booted kernel, where autoconfiguration would
+ * mask a missing tag.
  *
  * @author Daniel West <daniel@silverback.is>
  */
-class ServicesResetterTest extends KernelTestCase
+class ServicesResetterTest extends TestCase
 {
     /**
-     * Services that accumulate state during a request and must be emptied between requests.
+     * Config file => service ids defined in it that accumulate state during a request and must be
+     * emptied between requests.
      *
-     * Add to this list whenever a bundle service gains mutable per-request state — or, better,
-     * scope the state so it cannot outlive its request (UploadableFileManager keys its markers in a
-     * WeakMap by the resource they belong to, so it needs no reset at all).
+     * Add here whenever a bundle service gains mutable per-request state — or, better, scope the
+     * state so it cannot outlive its request (UploadableFileManager keys its markers in a WeakMap by
+     * the resource they belong to, so it needs no reset at all).
      */
     private const MUST_BE_RESETTABLE = [
+        'services.php' => [
+            // Profiler panel data gathered across the request
+            'silverback.api_components.data_collector.data',
+            // Holds the JWT to be written as a cookie on the response
+            'silverback.security.jwt_event_listener',
+        ],
         // Queues objects changed during the request, flushed on propagate()
-        'silverback.api_components.mercure.resource_publisher',
+        'services_doctrine_orm_mercure_publisher.php' => ['silverback.api_components.mercure.resource_publisher'],
         // Same, for cache invalidation
-        'silverback.api_components.http_cache.purger',
-        // Profiler panel data gathered across the request
-        'silverback.api_components.data_collector.data',
-        // Holds the JWT to be written as a cookie on the response
-        'silverback.security.jwt_event_listener',
+        'services_doctrine_orm_http_cache_purger.php' => ['silverback.api_components.http_cache.purger'],
     ];
 
-    public function test_bundle_services_holding_request_state_are_registered_with_the_services_resetter(): void
+    public function test_bundle_services_holding_request_state_are_tagged_kernel_reset(): void
     {
-        self::bootKernel();
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../src/Resources/config'));
 
-        $resetter = self::getContainer()->get('services_resetter');
-        self::assertInstanceOf(ServicesResetter::class, $resetter);
+        foreach (self::MUST_BE_RESETTABLE as $file => $serviceIds) {
+            $loader->load($file);
 
-        $resetMethods = (new \ReflectionProperty(ServicesResetter::class, 'resetMethods'))->getValue($resetter);
-
-        foreach (self::MUST_BE_RESETTABLE as $serviceId) {
-            self::assertArrayHasKey(
-                $serviceId,
-                $resetMethods,
-                \sprintf('"%s" holds per-request state but is not tagged kernel.reset, so it would carry that state into the next request in worker mode.', $serviceId)
-            );
+            foreach ($serviceIds as $serviceId) {
+                self::assertTrue(
+                    $container->hasDefinition($serviceId),
+                    \sprintf('"%s" is not defined in %s — has it been renamed?', $serviceId, $file)
+                );
+                self::assertTrue(
+                    $container->getDefinition($serviceId)->hasTag('kernel.reset'),
+                    \sprintf('"%s" holds per-request state but is not tagged kernel.reset, so it would carry that state into the next request in worker mode.', $serviceId)
+                );
+            }
         }
-
-        // Booting a kernel in debug registers Symfony's ErrorHandler, which PHPUnit reports as a
-        // risky test. It cannot be handed back from here (restore_exception_handler does not clear
-        // it), and risky is not a failure, so the notice is accepted.
-        self::ensureKernelShutdown();
     }
 }


### PR DESCRIPTION
Main went red on merge of #209.

`ServicesResetterTest` booted a kernel to inspect the `services_resetter`. Booting in debug registers Symfony's ErrorHandler, which PHPUnit reports as Risky — and **Infection's initial test run fails on Risky**, so that one test aborted the whole mutation gate in the coverage job (`PHPUnit (Symfony 7.4)`), even though `failOnRisky` is unset for the normal suite. I'd noted the risky flag as cosmetic when I wrote it; it wasn't.

The config files are now loaded into a bare `ContainerBuilder` and the `kernel.reset` tag asserted on each definition. That is also the stronger assertion: the claim is that the bundle tags these *explicitly*, because an application may disable autoconfiguration — and in a booted kernel autoconfiguration would add the tag anyway and mask a missing one. Verified failing when a tag is removed.

Locally: 579 unit tests green, Infection MSI 85% against the 80 gate, php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)