### PR TITLE
Fix /resend-verify-email/{username} being unroutable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,21 @@ $topicBuilder->onRoutesCreated(function (array $childBuilders) use ($intro) {
 
 ## Open Issues — Context for Future Work
 
+### [#216](https://github.com/components-web-app/api-components-bundle/issues/216) — `/resend-verify-email/{username}` is not routable, a duplicate path shadows it
+
+Found 2026-08-14 from the Nuxt module side (module issue #281). Filed as bundle issue #216.
+
+`src/Resources/config/routing/security.php:42-45` registers `api_components_resend_email_verification` at **`/verify-email/{username}/{token}`** — byte-identical to `api_components_verify_email` two entries above (`:37-40`), which points at `VerifyEmailAddressAction`. Symfony resolves duplicate paths to the **first** match, so `ResendVerifyEmailAddressAction` is unreachable: the route it is presumably meant to serve, **`/resend-verify-email/{username}`**, is registered nowhere.
+
+The Nuxt module calls exactly that path — `Auth.resendVerifyEmail()` → `/resend-verify-email/{username}` (`cwa-nuxt-3-module/src/runtime/api/auth.ts:97`). Compare the sibling entry `api_components_resend_new_email_verification` at `/resend-verify-new-email/{username}` (`:47-50`), which is correct and is what `resendVerifyNewEmail()` hits.
+
+**Expected fix:** change the `api_components_resend_email_verification` path to `/resend-verify-email/{username}` and drop the `{token}` placeholder (a resend needs only the username — `ResendVerifyEmailAddressAction` generates a fresh token).
+
+**Why it went unnoticed:** the module's `useResendVerifyEmail()` composable had a separate bug (module #281, now fixed) where any non-`'current'` type fell through to the *new email* endpoint, so the broken route was rarely exercised. With the module fixed, "resend verification for my current address" will now hit the missing path and surface as a 404 (rendered as "Username not found" by the composable's error handling) until this is corrected.
+
+**Worth a Behat scenario** pinning that each of the four security routes resolves to its intended controller — a duplicate path is invisible to unit tests.
+
+
 ### #186 — `#[Publishable]` on AbstractPage / AbstractPageData — page-level draft/live toggle
 
 Currently the only "draft" signal for a page is the absence of a Route. Once a page is live, there is no way to take it offline without deleting the route (losing URL history and redirects).
@@ -633,6 +648,16 @@ Publishing a draft that genuinely has no file still clears the published file (p
 **Behat cannot reach the shared-path case through the API** (cloning always copies the file), so `the resource :resource has the same file as the resource :other` sets it up directly. Verified to fail against the old ordering before the fix landed.
 
 References: `src/Helper/Uploadable/UploadableFileManager.php` (`getStoredFilePaths`, `deleteOrphanedFiles`, `removeFilepathValue`, `copyFilepath`), `src/EventListener/Api/PublishableEventListener.php`.
+
+---
+
+### Security routes: one path each, and unknown usernames are 404 ✓ **DONE**
+
+`src/Resources/config/routing/security.php` had `api_components_resend_email_verification` registered at `/verify-email/{username}/{token}` — **the same path as `api_components_verify_email`**. Symfony resolves a duplicate path to the first match, so `ResendVerifyEmailAddressAction` was unreachable and the path the Nuxt module calls (`/resend-verify-email/{username}`, `auth.ts:97`) was registered nowhere. Correct path: username only, no token — the action *generates* a token, and its sibling `/resend-verify-new-email/{username}` already had that shape.
+
+**A duplicate path fails nothing.** No test errors; one route silently never runs. It survived because no scenario had ever hit that route — every other security route did have one. `bin/console debug:router` is the quick check.
+
+`UserDataProcessor::findUserByUsername()` **throws** `InvalidArgumentException('Username not found')` rather than returning null, so the `if (!$user)` guards after it are only reachable via the request-limit path. Every action calling into it must catch and return **404** (as `PasswordRequestAction` always did); without the catch an unknown username is a 500 leaking the exception message. `ResendVerifyEmailAddressAction` and `ResendVerifyNewEmailAddressAction` now do — the latter's 500 was already live, just untested.
 
 ---
 

--- a/features/user/new_email_address.feature
+++ b/features/user/new_email_address.feature
@@ -171,6 +171,14 @@ Feature: Register process via a form
     Then the response status code should be 200
     And I should get a "change_email_confirmation" email sent to the email address "user@example.com"
 
+  # Same uncaught InvalidArgumentException as its resend-verify-email sibling: this route has always
+  # been reachable, so the 500 was live — it just had no scenario for an unknown username.
+  Scenario: Requesting a new email address confirmation for an unknown username is a 404, not an error
+    Given I add "referer" header equal to "http://www.website.com"
+    When I send a "GET" request to "/resend-verify-new-email/no_user"
+    Then the response status code should be 404
+    And I should not receive any emails
+
   Scenario: I can verify my new email address
     Given there is a user with the username "my_username" password "password" and role "ROLE_USER" and the email address "old@email.com"
     And the user has a new email address "new@email.com" and confirmation token "abc123"

--- a/features/user/verify_email_address.feature
+++ b/features/user/verify_email_address.feature
@@ -47,6 +47,30 @@ Feature: Email address verification
     Then the response status code should be 200
     And the user "my_username" should have a verified email address
 
+  # ResendVerifyEmailAddressAction generates a fresh token, so its route takes a username and no
+  # token — matching its sibling /resend-verify-new-email/{username}. It was registered at
+  # /verify-email/{username}/{token}, a duplicate of the route above, and Symfony resolves a
+  # duplicate path to the first match: the action was unreachable and the path the module calls was
+  # registered nowhere. Nothing failed, because no scenario had ever hit this route.
+  Scenario: I can request a new email address verification email
+    Given there is a user with the username "my_username" password "password" and role "ROLE_USER" and the email address "user@example.com"
+    And the user email is not verified
+    And I add "referer" header equal to "http://www.website.com"
+    When I send a "GET" request to "/resend-verify-email/my_username"
+    Then the response status code should be 200
+    And I should get a "verify_email" email sent to the email address "user@example.com"
+
+  # UserDataProcessor::findUserByUsername throws rather than returning null, so without a catch an
+  # unknown username is an uncaught exception — a 500 leaking "Username not found". 404 matches
+  # PasswordRequestAction, the only one of these actions that already handled it.
+  Scenario: Requesting a verification email for an unknown username is a 404, not an error
+    Given there is a user with the username "my_username" password "password" and role "ROLE_USER"
+    And the user email is not verified
+    And I add "referer" header equal to "http://www.website.com"
+    When I send a "GET" request to "/resend-verify-email/no_user"
+    Then the response status code should be 404
+    And I should not receive any emails
+
   Scenario Outline: I cannot verify email addresses with incorrect parameters
     Given there is a user with the username "my_username" password "password" and role "ROLE_USER"
     And the user email is not verified with the token "abc123"

--- a/src/Action/User/ResendVerifyEmailAddressAction.php
+++ b/src/Action/User/ResendVerifyEmailAddressAction.php
@@ -11,6 +11,7 @@
 
 namespace Silverback\ApiComponentsBundle\Action\User;
 
+use Silverback\ApiComponentsBundle\Exception\InvalidArgumentException;
 use Silverback\ApiComponentsBundle\Helper\User\UserDataProcessor;
 use Silverback\ApiComponentsBundle\Helper\User\UserMailer;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +29,16 @@ final readonly class ResendVerifyEmailAddressAction
 
     public function __invoke(string $username): Response
     {
-        $user = $this->userDataProcessor->updateVerifyEmailToken($username);
+        try {
+            $user = $this->userDataProcessor->updateVerifyEmailToken($username);
+        } catch (InvalidArgumentException $e) {
+            // findUserByUsername throws rather than returning null for an unknown username, so
+            // without this the response is a 500 leaking "Username not found". Matches
+            // PasswordRequestAction.
+            return new Response(null, Response::HTTP_NOT_FOUND);
+        }
+
+        // A null user here means the request limit was reached: accept quietly and send nothing.
         if (!$user) {
             $response = new Response(null, Response::HTTP_OK);
             $response->setCache([

--- a/src/Action/User/ResendVerifyNewEmailAddressAction.php
+++ b/src/Action/User/ResendVerifyNewEmailAddressAction.php
@@ -11,6 +11,7 @@
 
 namespace Silverback\ApiComponentsBundle\Action\User;
 
+use Silverback\ApiComponentsBundle\Exception\InvalidArgumentException;
 use Silverback\ApiComponentsBundle\Helper\User\UserDataProcessor;
 use Silverback\ApiComponentsBundle\Helper\User\UserMailer;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +29,16 @@ final readonly class ResendVerifyNewEmailAddressAction
 
     public function __invoke(string $username): Response
     {
-        $user = $this->userDataProcessor->updateNewEmailToken($username);
+        try {
+            $user = $this->userDataProcessor->updateNewEmailToken($username);
+        } catch (InvalidArgumentException $e) {
+            // findUserByUsername throws rather than returning null for an unknown username, so
+            // without this the response is a 500 leaking "Username not found". Matches
+            // PasswordRequestAction.
+            return new Response(null, Response::HTTP_NOT_FOUND);
+        }
+
+        // A null user here means the request limit was reached: accept quietly and send nothing.
         if (!$user) {
             $response = new Response(null, Response::HTTP_OK);
             $response->setCache([

--- a/src/Resources/config/routing/security.php
+++ b/src/Resources/config/routing/security.php
@@ -40,7 +40,11 @@ return static function (RoutingConfigurator $routes): void {
         ->controller(VerifyEmailAddressAction::class);
 
     $routes
-        ->add('api_components_resend_email_verification', '/verify-email/{username}/{token}')
+        // Takes a username and no token: this action generates a fresh one. Sibling of
+        // /resend-verify-new-email/{username} below. Registering it at the same path as
+        // api_components_verify_email above made it unreachable — Symfony resolves a duplicate path
+        // to the first match — and left the path the Nuxt module calls registered nowhere.
+        ->add('api_components_resend_email_verification', '/resend-verify-email/{username}')
         ->methods(['GET'])
         ->controller(ResendVerifyEmailAddressAction::class);
 


### PR DESCRIPTION
Closes #216.

`api_components_resend_email_verification` was registered at `/verify-email/{username}/{token}` — **the same path as `api_components_verify_email`**. Symfony resolves a duplicate path to the first match, so `ResendVerifyEmailAddressAction` was unreachable, and `/resend-verify-email/{username}`, which the Nuxt module calls (`auth.ts:97`), was registered nowhere and 404d.

The correct path takes a username and no token: the action *generates* a fresh token, and its sibling `/resend-verify-new-email/{username}` already had that shape. `debug:router` now shows five distinct paths.

## A second bug, exposed by making the route reachable

`UserDataProcessor::findUserByUsername()` **throws** rather than returning null for an unknown username, so an uncaught `InvalidArgumentException` came back as a **500 leaking "Username not found"**. Both resend actions now catch it and return 404, matching `PasswordRequestAction`, which always did.

**This one was already live.** `/resend-verify-new-email/{username}` has always been routable — it just had no scenario for an unknown username. Fixed and covered here too, since it's the same one-line pattern in the adjacent action.

The `if (!$user)` branch after that call is not dead: it's the request-limit path, which correctly answers 200 and sends nothing.

## On the issue's suggestion of route-resolution tests

Rather than assert the router table, I checked coverage per route. Every security route already had a Behat scenario hitting its real path — `password/reset/request`, `confirm-email`, `verify-email`, `resend-verify-new-email` — except this one. That gap is exactly why the duplicate survived: a duplicate path fails nothing, one route just silently never runs. All five now have scenarios covering the happy path and an unknown username, which catches reachability where it matters.

## Testing

Both failures were reproduced before fixing — 404 for the missing route, then 500 for the unknown username.

451 Behat scenarios, 579 unit tests, Infection MSI 85% against the 80 gate, php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)