### PR TITLE
Fix Behat code coverage pipeline (#218)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,17 +197,28 @@ jobs:
         run: |
           mkdir -p build/logs/behat
           if [ "$COVERAGE" = '1' ]; then
-            php -d memory_limit=-1 -d error_reporting="E_ALL & ~E_NOTICE & ~E_DEPRECATED" vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/junit --profile=default-coverage --no-interaction --colors --tags='~@wip'
+            php -d memory_limit=-1 -d pcov.enabled=1 -d error_reporting="E_ALL & ~E_NOTICE & ~E_DEPRECATED" vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/junit --profile=default-coverage --no-interaction --colors --tags='~@wip'
           else
             php -d memory_limit=-1 -d error_reporting="E_ALL & ~E_NOTICE & ~E_DEPRECATED" vendor/bin/behat --format=progress --out=std --format=junit --out=build/logs/behat/junit --profile=default --no-interaction --colors --tags='~@wip'
           fi
-      - name: Merge code coverage reports
+      - name: Verify code coverage report is not empty
         if: matrix.coverage
         run: |
-          wget -qO /usr/local/bin/phpcov https://phar.phpunit.de/phpcov.phar
-          chmod +x /usr/local/bin/phpcov
-          phpcov merge --clover build/logs/behat/clover.xml build/coverage
-        continue-on-error: true
+          report=build/logs/behat/clover.xml
+          if [ ! -s "$report" ]; then
+            echo "::error::Behat coverage report $report is missing or empty"
+            exit 1
+          fi
+          php -r '
+            $metrics = simplexml_load_file($argv[1])->project->metrics;
+            $covered = (int) $metrics["coveredstatements"];
+            $total = (int) $metrics["statements"];
+            printf("Behat coverage: %d/%d covered statements across %d files%s", $covered, $total, (int) $metrics["files"], PHP_EOL);
+            if ($covered < 1000) {
+                fwrite(STDERR, "::error::Behat coverage report contains too few covered statements - the coverage pipeline is broken" . PHP_EOL);
+                exit(1);
+            }
+          ' "$report"
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ php -d memory_limit=256M vendor/bin/phpunit
 # Integration tests (Behat)
 php -d memory_limit=256M vendor/bin/behat
 
+# Behat with code coverage (needs pcov; writes build/logs/behat/clover.xml)
+php -d memory_limit=-1 -d pcov.enabled=1 vendor/bin/behat --profile=default-coverage
+
 # Database setup for tests
 php tests/Functional/app/bin/console -e test doctrine:database:create
 php tests/Functional/app/bin/console -e test doctrine:migrations:migrate --no-interaction
@@ -41,6 +44,8 @@ php tests/Functional/app/bin/console -e test doctrine:schema:validate
 ```
 
 Behat features live in `features/`. PHPUnit tests in `tests/`. Behat coverage is more extensive than unit — prefer adding Behat scenarios for new API behaviour, unit tests for pure logic.
+
+**Behat coverage convention**: `CoverageContext` (registered in the `default-coverage` profile) writes Clover XML **directly** to `build/logs/behat/clover.xml`, which Codecov consumes as-is. Do not reintroduce an intermediate `.cov` + `phpcov merge` step — current `phpcov` releases only read php-code-coverage's newer serialization format, which the version installed here cannot write. The filter must be populated with individual file paths (`Filter::includeFiles()` over a file iterator); `Filter::includeFile()` given a directory silently records nothing. CI fails the Behat job if the report has fewer than 1000 covered statements.
 
 ## Architecture
 

--- a/features/bootstrap/CoverageContext.php
+++ b/features/bootstrap/CoverageContext.php
@@ -17,9 +17,15 @@ use SebastianBergmann\CodeCoverage\CodeCoverage;
 use SebastianBergmann\CodeCoverage\Driver\Selector;
 use SebastianBergmann\CodeCoverage\Filter;
 use SebastianBergmann\CodeCoverage\Report\Clover;
+use SebastianBergmann\FileIterator\Facade as FileIteratorFacade;
 
 /**
  * Behat coverage.
+ *
+ * Writes a Clover XML report directly. The report is consumed as-is by Codecov -
+ * there is deliberately no intermediate `.cov` + `phpcov merge` step: current
+ * phpcov releases only read the newer php-code-coverage serialization format,
+ * which the version this project installs cannot write.
  *
  * @author eliecharra
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -27,21 +33,31 @@ use SebastianBergmann\CodeCoverage\Report\Clover;
  */
 final class CoverageContext implements Context
 {
-    /**
-     * @var CodeCoverage
-     */
-    private static $coverage;
+    private const DEFAULT_TARGET = '/build/logs/behat/clover.xml';
+
+    private static ?CodeCoverage $coverage = null;
 
     /**
      * @BeforeSuite
      */
-    public static function setup()
+    public static function setup(): void
     {
+        $projectDir = self::projectDir();
+
         $filter = new Filter();
-        $filter->includeFile(__DIR__ . '/../../src');
-        $codeCoverageDriver = (new Selector())->forLineCoverage($filter);
+        // Filter::includeFile() takes a single file - a directory registers a path that matches
+        // nothing, so every file would be excluded and no coverage recorded at all.
+        $filter->includeFiles(
+            (new FileIteratorFacade())->getFilesAsArray(
+                $projectDir . '/src',
+                '.php',
+                '',
+                [$projectDir . '/src/Resources/config']
+            )
+        );
+
         self::$coverage = new CodeCoverage(
-            $codeCoverageDriver,
+            (new Selector())->forLineCoverage($filter),
             $filter
         );
     }
@@ -49,25 +65,43 @@ final class CoverageContext implements Context
     /**
      * @AfterSuite
      */
-    public static function teardown()
+    public static function teardown(): void
     {
-        $feature = getenv('FEATURE') ?: 'behat';
-        (new Clover())->process(self::$coverage, __DIR__ . "/../../build/coverage/coverage-$feature.cov");
+        if (null === self::$coverage) {
+            return;
+        }
+
+        (new Clover())->process(self::$coverage, self::target());
     }
 
     /**
      * @BeforeScenario
      */
-    public function before(BeforeScenarioScope $scope)
+    public function before(BeforeScenarioScope $scope): void
     {
-        self::$coverage->start("{$scope->getFeature()->getTitle()}::{$scope->getScenario()->getTitle()}");
+        self::$coverage?->start("{$scope->getFeature()->getTitle()}::{$scope->getScenario()->getTitle()}");
     }
 
     /**
      * @AfterScenario
      */
-    public function after()
+    public function after(): void
     {
-        self::$coverage->stop();
+        self::$coverage?->stop();
+    }
+
+    private static function target(): string
+    {
+        $target = getenv('BEHAT_COVERAGE_CLOVER');
+        if (\is_string($target) && '' !== $target) {
+            return $target;
+        }
+
+        return self::projectDir() . self::DEFAULT_TARGET;
+    }
+
+    private static function projectDir(): string
+    {
+        return \dirname(__DIR__, 2);
     }
 }


### PR DESCRIPTION
Fixes #218.

## What was wrong

The Behat coverage pipeline recorded nothing, so Codecov's `behat` flag contributed no data and project totals were PHPUnit-only. Any change covered only by Behat scenarios reported 0% patch coverage.

Three defects, not two. The issue identified the first two from static analysis; the third only shows up when you look at what CI actually downloads.

**1. The coverage filter included nothing.** `CoverageContext::setup()` called `Filter::includeFile()` with the `src` *directory*. Confirmed against `vendor/phpunit/php-code-coverage/src/Filter.php`: `includeFile()` realpaths its argument and stores it as a single key in `$files`; `isExcluded()` then does `!isset($this->files[$filename])`, so no source file ever matches. `PcovDriver::stop()` intersects pcov's waiting file list with `$filter->files()` and gets an empty array. Nothing was recorded.

**2. Clover XML was written to a `.cov` filename.** `phpcov merge` does not read Clover.

**3. Writing a real `.cov` would not have fixed it either.** The issue suggested `(new PHP())->process(...)`. That does not work with the phpcov CI downloads. `ci.yml` wgets the *latest* `phpcov.phar` — currently 13.1.0 — whose `MergeCommand` delegates to `SebastianBergmann\CodeCoverage\Serialization\Merger`. Its `Unserializer::unserialize()` requires the first line of each `.cov` to match `^<\?php \/\/ phpunit\/php-code-coverage serialization format (\d+)$`, and throws `FileCouldNotBeReadException` otherwise. The installed php-code-coverage is 12.5.7, which has no `Serialization` namespace at all — its `Report\PHP` writes a bare `<?php return \unserialize(...)`, which that unserializer rejects. So the merge step was unfixable without a dependency bump.

`Filter` in 12.5.7 also has no `includeDirectory()` method (only `includeFile()` / `includeFiles()`), so the issue's suggested one-word fix would not have compiled.

## What changed

- `CoverageContext` populates the filter with every `src/**/*.php` path via `SebastianBergmann\FileIterator\Facade` (already installed as a php-code-coverage dependency). `src/Resources/config` is excluded to match the PHPUnit source scope and `codecov.yml`'s ignore list.
- `CoverageContext` writes Clover XML directly to `build/logs/behat/clover.xml` — the path Codecov already picks up — overridable via `BEHAT_COVERAGE_CLOVER`. The intermediate `.cov` is gone.
- The `Merge code coverage reports` step is removed from `ci.yml` and replaced with `Verify code coverage report is not empty`, which fails the job if the report is missing, empty, or has under 1000 covered statements. The old step had `continue-on-error: true` and reported success while producing no file — that is what hid this for so long.
- `-d pcov.enabled=1` added to the coverage Behat invocation so the run does not depend on setup-php's ini defaults.
- Brief note in `CLAUDE.md` recording why there is no `phpcov merge` step, so it does not get reintroduced.

No `src/` code changed, so the Infection gate is untouched.

## How it was verified

Locally, PHP 8.5.9 with pcov.

Small subset first — `features/user/verify_email_address.feature` under `--profile=default-coverage`, 7 scenarios:

```
files=294 statements=6548 coveredstatements=1614 (24.65%)
ResendVerifyEmailAddressAction.php -> statements=20 covered=13
VerifyEmailAddressAction.php       -> statements=11 covered=11
UserRepository.php                 -> statements=48 covered=10
files with >0 covered statements: 134
```

`ResendVerifyEmailAddressAction.php` is the file whose 0% patch coverage on #217 surfaced this. Before the fix the report did not exist at all.

Full suite under the coverage profile — 451 scenarios, 3374 steps, all passing:

```
files=294 statements=6548 covered=4402 (67.23%)
```

294 files is exactly `find src -name '*.php' -not -path 'src/Resources/config/*' | wc -l`, so uncovered files are included too and the percentage is not inflated by only counting executed files.

Comparing the two clover reports line by line over `src`:

| | covered / statements | |
|---|---|---|
| PHPUnit alone | 1810 / 6549 | 27.64% |
| Behat alone | 4402 / 6548 | 67.23% |
| Union | 5375 / 6549 | 82.07% |

The 27.64% figure matches Codecov's current ~28.5% project total, which corroborates that the `behat` flag has been contributing nothing. Expect the project total to rise substantially once this lands; I have not tried to predict where it settles since Codecov's carry-forward and ignore rules differ from this local calculation.

No regressions:

- `vendor/bin/behat` (default profile, full): 451 scenarios, 3374 steps, all passing
- `vendor/bin/phpunit`: 579 tests, 1480 assertions, 113 PHPUnit Notices (pre-existing), **0 risky**
- `vendor/bin/phpunit --configuration=phpunit.coverage.xml.dist` (the config Infection's initial run uses): same 579 / 0 risky
- `vendor/bin/php-cs-fixer fix`: 0 of 413 files changed
- The CI verification step's shell + PHP was executed locally against the real report and prints `Behat coverage: 4402/6548 covered statements across 294 files`, exit 0

## CI result on this PR

All jobs green (Scrutinizer excepted — chronically failing on this repo, unrelated).

The new verification step printed, in the `Behat (Symfony 7.4) (PHP 8.5)` job:

```
Behat coverage: 4402/6548 covered statements across 294 files
```

— identical to the local run — and Codecov ingested `build/logs/behat/clover.xml` under the `behat` flag.

Codecov reports project coverage **28.54% -> 83.07% (+54.53%)**, with the `behat` flag appearing for the first time at 68.72%; the `phpunit` flag is unchanged at 28.54%. Hits went from 2112 to 6147 with no change to the line count, i.e. the same code, previously unmeasured.
