### PR TITLE
Enforce createdAt on write, and resolve every user.email_verification config key (#213, #214)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -800,6 +800,32 @@ Three papercuts found by the docs accuracy audit, all in `src/Maker/`.
 
 **#215 — `make:api-component --timestamped` help said `updatedAt`.** `TimestampedTrait` declares `$createdAt` and `$modifiedAt`; there is no `updatedAt`. Both the option description and the interactive question now say `modifiedAt`, and `MakeApiComponentTest` reflects over `TimestampedTrait` so a future rename of the trait fields fails the test rather than silently desyncing the help text.
 
-Two stale `updatedAt` mentions remain in unrelated docblocks (`src/Serializer/MappingLoader/TimestampedLoader.php`, `src/Serializer/MappingLoader/UploadableLoader.php`) — left alone to avoid colliding with concurrent work in `src/Serializer/`.
+The two stale `updatedAt` mentions in `src/Serializer/MappingLoader/TimestampedLoader.php` and `src/Serializer/MappingLoader/UploadableLoader.php` were corrected on the #213/#214 branch (`UploadableLoader`'s was additionally a copy-paste describing the *timestamped* groups).
 
 Tests: `tests/Maker/MakePageDataTest.php`, `tests/Maker/MakeApiComponentTest.php`.
+
+---
+
+### #213 / #214 — Two guards that looked like they worked and never ran ✓ **DONE**
+
+Both found by the docs accuracy audit. Neither was quite what the issue described, and in both cases the correction changed which fix was right.
+
+**#213 — `createdAt` was writable, but only on entities that skip `TimestampedTrait`.** `TimestampedDataPersister` keeps whatever `createdAt` an existing object carries, and the serializer has already written the request body onto that object by the time it runs. `TimestampedTrait::setCreatedAt()` ignores a second value, and PropertyAccess prefers the setter over the public property — so every entity in the bundle was shielded and the bug was invisible. An application entity is under no obligation to use the trait.
+
+**Dropping the `:timestamped:write` group is not enough on its own.** `TimestampedContextBuilder` returns early when `$context['groups']` is empty, so a resource that declares no serialization groups gets no group filtering at all. Enforcement therefore lives in `TimestampedNormalizer::denormalize()`: capture `createdAt` off the object being populated *before* denormalizing, restore it after. The write group is still dropped from `createdAt`, but that only stops it being advertised as writable in the generated input schema — it is documentation, not enforcement. `persistTimestampedFields($entity, true)` is untouched, so every seeding path (`CwaFixtureBuilder`, `RouteGenerator`, `UserFactory`, `DoctrineContext`) is unaffected.
+
+> **`OBJECT_TO_POPULATE` is not always an instance of `$type`.** Denormalizing a collection property (e.g. `ComponentGroup.pages`) leaves the Doctrine `PersistentCollection` in that context key while `$type` is still the entity class. Anything reading bundle metadata off the object-to-populate must gate on `instanceof $type` — the first version of this fix asked the attribute reader for a `Timestamped` configuration on a `PersistentCollection` and 500'd two unrelated Behat scenarios.
+
+**#214 — `isRequired()` under a node that carries a default is never enforced.** `ArrayNode::finalizeValue()` inserts the default and `continue`s without finalising, so the required-child check never runs for an omitted node. `user.email_verification` resolved to `['enabled' => true]`, the extension read keys that were not there (26 undefined-array-key warnings on a minimal config), and services typed `bool` were wired with `null`. The same declaration made the node impossible to configure *partially* — supplying anything, including `enabled: false`, ran finalisation and hard-failed on the first missing required child.
+
+**Convention going forward: never put `isRequired()` under a node with `addDefaultsIfNotSet()` or `canBeDisabled()`.** Give the child a real default instead. If a combination is genuinely invalid, express it as a node-level `->validate()` — that runs only when the node is present, which is the only time the combination can be expressed, so it cannot break an application that omits the node. `user.email_verification` now rejects `verify_on_register`/`verify_on_change` without a redirect target that way.
+
+Defaults were chosen to be **all-off** rather than "correct": `deny_unverified_login: true` would lock users out of an application that never configured verification, and `verify_on_register: true` would send emails for which no redirect target exists (`AbstractUserEmailFactory::getTokenPath()` throws). Making the children genuinely required was rejected as a breaking change — it would force config on every application currently omitting the node.
+
+The `email` sub-node had no default of its own, so `new_email_confirmation` and `password_reset` had the same defect; all three now use `addDefaultsIfNotSet()` with `default_redirect_path` defaulting to null (which is exactly the previous effective behaviour — `AbstractUserEmailFactory` accepts null and throws a clear exception at send time). `email_verification.enabled` is now actually honoured by `VerifyEmailFactory`, which previously received a hardcoded `true`.
+
+**Still carrying the same latent pattern, deliberately unfixed** because every fix forces configuration onto existing applications — decide before touching: `user.class_name`, `refresh_token.*`, `publishable.permission`, and `refresh_token.options.class` (read unguarded under the doctrine storage branch).
+
+Tests: `tests/DependencyInjection/ConfigurationTest.php` and `tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php` (bare `ContainerBuilder`, no kernel boot — see the Risky/Infection warning above), `tests/Serializer/MappingLoader/TimestampedLoaderTest.php`, `tests/Serializer/Normalizer/TimestampedNormalizerTest.php`, and `features/timestamped/timestamped.feature` (PATCH scenarios for both the guarded and unguarded entity shapes).
+
+> **Newly covering a large declarative file costs MSI.** These DI tests pulled `Configuration.php` and `SilverbackApiComponentsExtension.php` into the covered set for the first time, so their mutants started counting where `--only-covered` had been skipping them — MSI fell from 85% to 82% against an 80% gate. The fix was to broaden the extension test to assert the wiring it performs, not to exclude the files.

--- a/features/bootstrap/DoctrineContext.php
+++ b/features/bootstrap/DoctrineContext.php
@@ -45,7 +45,9 @@ use Silverback\ApiComponentsBundle\Repository\User\UserRepositoryInterface;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyComponent;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyCustomTimestamped;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyPublishableComponent;
+use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyTimestamped;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyTimestampedWithSerializationGroups;
+use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\DummyUnguardedTimestamped;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\PageData;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\PageDataWithComponent;
 use Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity\RefreshToken;
@@ -373,6 +375,32 @@ final class DoctrineContext implements Context
         $this->manager->persist($component);
         $this->manager->flush();
         $this->restContext->resources['dummy_custom_timestamped'] = $this->iriConverter->getIriFromResource($component);
+    }
+
+    /**
+     * @Given there is a DummyTimestamped resource created at :createdAt
+     */
+    public function thereIsADummyTimestampedResourceCreatedAt(string $createdAt): void
+    {
+        $component = new DummyTimestamped();
+        $component->createdAt = new \DateTimeImmutable($createdAt);
+        $component->modifiedAt = new \DateTime($createdAt);
+        $this->manager->persist($component);
+        $this->manager->flush();
+        $this->restContext->resources['dummy_timestamped'] = $this->iriConverter->getIriFromResource($component);
+    }
+
+    /**
+     * @Given there is a DummyUnguardedTimestamped resource created at :createdAt
+     */
+    public function thereIsADummyUnguardedTimestampedResourceCreatedAt(string $createdAt): void
+    {
+        $component = new DummyUnguardedTimestamped();
+        $component->createdAt = new \DateTimeImmutable($createdAt);
+        $component->modifiedAt = new \DateTime($createdAt);
+        $this->manager->persist($component);
+        $this->manager->flush();
+        $this->restContext->resources['dummy_unguarded_timestamped'] = $this->iriConverter->getIriFromResource($component);
     }
 
     /**

--- a/features/timestamped/timestamped.feature
+++ b/features/timestamped/timestamped.feature
@@ -32,6 +32,34 @@ Feature: Timestamped resources
     And the Mercure message should contain timestamped fields
 
   @loginUser
+  Scenario: I should not be able to overwrite createdAt with a PATCH request
+    Given there is a DummyTimestamped resource created at "2001-02-03T04:05:06+00:00"
+    When I send a "PATCH" request to the resource "dummy_timestamped" with body:
+    """
+    {
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modifiedAt": "1970-01-01T00:00:00+00:00"
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "createdAt" should be equal to "2001-02-03T04:05:06+00:00"
+    And the JSON node "modifiedAt" should be now
+
+  @loginUser
+  Scenario: I should not be able to overwrite createdAt with a PATCH request on a resource without a guarded setter
+    Given there is a DummyUnguardedTimestamped resource created at "2001-02-03T04:05:06+00:00"
+    When I send a "PATCH" request to the resource "dummy_unguarded_timestamped" with body:
+    """
+    {
+      "createdAt": "1970-01-01T00:00:00+00:00",
+      "modifiedAt": "1970-01-01T00:00:00+00:00"
+    }
+    """
+    Then the response status code should be 200
+    And the JSON node "createdAt" should be equal to "2001-02-03T04:05:06+00:00"
+    And the JSON node "modifiedAt" should be now
+
+  @loginUser
   Scenario: Use custom timestamped fields
     Given there is a DummyCustomTimestamped resource
     When I send a "GET" request to the resource "dummy_custom_timestamped"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -176,27 +176,48 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('email_verification')
                             ->canBeDisabled()
                             ->addDefaultsIfNotSet()
+                            // Every child resolves to a value. An `isRequired()` child under a node
+                            // that carries a default is never enforced — ArrayNode::finalizeValue()
+                            // inserts the default and skips finalisation for an omitted node — so
+                            // the extension read keys that were not there. Defaults are all-off:
+                            // an application that never mentions email verification must not start
+                            // sending verification emails it has given no redirect target for, and
+                            // must not have its users locked out of logging in.
                             ->children()
                                 ->arrayNode('email')
+                                    ->addDefaultsIfNotSet()
                                     ->children()
-                                        ->scalarNode('redirect_path_query')->end()
-                                        ->scalarNode('default_redirect_path')->isRequired()->end()
+                                        ->scalarNode('redirect_path_query')->defaultNull()->end()
+                                        ->scalarNode('default_redirect_path')->defaultNull()->end()
                                         ->scalarNode('subject')->cannotBeEmpty()->defaultValue('Please verify your email')->end()
                                     ->end()
                                 ->end()
-                                ->booleanNode('default_value')->isRequired()->end()
-                                ->booleanNode('verify_on_change')->isRequired()->end()
-                                ->booleanNode('verify_on_register')->isRequired()->end()
-                                ->booleanNode('deny_unverified_login')->isRequired()->end()
+                                ->booleanNode('default_value')->defaultFalse()->end()
+                                ->booleanNode('verify_on_change')->defaultFalse()->end()
+                                ->booleanNode('verify_on_register')->defaultFalse()->end()
+                                ->booleanNode('deny_unverified_login')->defaultFalse()->end()
+                            ->end()
+                            // Only reachable when the node is present in the configuration, which is
+                            // exactly when it can be wrong: asking for verification emails without
+                            // telling the bundle where the link points can only fail later, inside
+                            // AbstractUserEmailFactory::getTokenPath(), at the moment a user
+                            // registers. Fail at compile time instead.
+                            ->validate()
+                                ->ifTrue(static fn (array $v): bool => ($v['enabled'] ?? true)
+                                    && ($v['verify_on_register'] || $v['verify_on_change'])
+                                    && null === $v['email']['default_redirect_path']
+                                    && null === $v['email']['redirect_path_query'])
+                                ->thenInvalid('One of "silverback_api_components.user.email_verification.email.default_redirect_path" or "…email.redirect_path_query" must be set to send verification emails.')
                             ->end()
                         ->end()
                         ->arrayNode('new_email_confirmation')
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->arrayNode('email')
+                                    ->addDefaultsIfNotSet()
                                     ->children()
-                                        ->scalarNode('redirect_path_query')->end()
-                                        ->scalarNode('default_redirect_path')->isRequired()->end()
+                                        ->scalarNode('redirect_path_query')->defaultNull()->end()
+                                        ->scalarNode('default_redirect_path')->defaultNull()->end()
                                         ->scalarNode('subject')->cannotBeEmpty()->defaultValue('Please confirm your new email address')->end()
                                     ->end()
                                 ->end()
@@ -207,9 +228,10 @@ class Configuration implements ConfigurationInterface
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->arrayNode('email')
+                                    ->addDefaultsIfNotSet()
                                     ->children()
-                                        ->scalarNode('redirect_path_query')->end()
-                                        ->scalarNode('default_redirect_path')->isRequired()->end()
+                                        ->scalarNode('redirect_path_query')->defaultNull()->end()
+                                        ->scalarNode('default_redirect_path')->defaultNull()->end()
                                         ->scalarNode('subject')->cannotBeEmpty()->defaultValue('Your password reset request')->end()
                                     ->end()
                                 ->end()

--- a/src/DependencyInjection/SilverbackApiComponentsExtension.php
+++ b/src/DependencyInjection/SilverbackApiComponentsExtension.php
@@ -232,7 +232,10 @@ class SilverbackApiComponentsExtension extends Extension implements PrependExten
         foreach ($mapping as $class => $key) {
             $definition = $container->findDefinition($class);
             $definition->setArgument('$subject', $config['user'][$key]['email']['subject']);
-            $definition->setArgument('$enabled', true);
+            // Only email_verification carries an on/off switch; the other two are always available.
+            // The switch was previously unreachable — the node could not be configured at all — so
+            // honouring it here cannot change the behaviour of any existing configuration.
+            $definition->setArgument('$enabled', $config['user'][$key]['enabled'] ?? true);
             $definition->setArgument('$defaultRedirectPath', $config['user'][$key]['email']['default_redirect_path']);
             $definition->setArgument('$redirectPathQueryKey', $config['user'][$key]['email']['redirect_path_query']);
         }

--- a/src/Serializer/MappingLoader/TimestampedLoader.php
+++ b/src/Serializer/MappingLoader/TimestampedLoader.php
@@ -16,7 +16,9 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 
 /**
- * Adds {CLASS}:timestamped serialization group on {CLASS}.createdAt and {CLASS}.updatedAt for Timestamped entities.
+ * Adds {CLASS}:timestamped:read to both timestamp fields of a Timestamped entity, and
+ * {CLASS}:timestamped:write to the modified date only — the creation date is never the client's to
+ * set. Field names come from the #[Timestamped] attribute and default to createdAt and modifiedAt.
  *
  * @author Daniel West <daniel@silverback.is>
  */
@@ -46,7 +48,6 @@ final class TimestampedLoader implements LoaderInterface
             && empty($attributeMetadata->getGroups())
         ) {
             $attributeMetadata->addGroup($readGroup);
-            $attributeMetadata->addGroup($writeGroup);
         }
 
         if (

--- a/src/Serializer/MappingLoader/UploadableLoader.php
+++ b/src/Serializer/MappingLoader/UploadableLoader.php
@@ -17,7 +17,8 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 
 /**
- * Adds {CLASS}:timestamped serialization group on {CLASS}.createdAt and {CLASS}.updatedAt for Timestamped entities.
+ * Adds {CLASS}:uploadable:read and {CLASS}:uploadable:write serialization groups to every
+ * #[UploadableField] property of an Uploadable entity.
  *
  * @author Daniel West <daniel@silverback.is>
  */

--- a/src/Serializer/Normalizer/TimestampedNormalizer.php
+++ b/src/Serializer/Normalizer/TimestampedNormalizer.php
@@ -55,12 +55,40 @@ class TimestampedNormalizer implements DenormalizerInterface, DenormalizerAwareI
     {
         $context[self::ALREADY_CALLED][] = $type;
 
-        $isNew = !isset($context[AbstractNormalizer::OBJECT_TO_POPULATE]);
+        $objectToPopulate = $context[AbstractNormalizer::OBJECT_TO_POPULATE] ?? null;
+        $isNew = null === $objectToPopulate;
+
+        // The creation date is not the client's to set. TimestampedDataPersister keeps whatever
+        // value the object carries when it is not new, so a `createdAt` in the request body would
+        // otherwise be written straight through. Capture the persisted value up front and put it
+        // back afterwards: reading it after denormalization is too late, it has already been
+        // replaced. TimestampedTrait's setCreatedAt() ignores a second value and so happens to
+        // block this, but an application entity is under no obligation to use the trait or to
+        // guard its own setter, so the protection has to live here.
+        //
+        // Only the resource being written has a creation date worth keeping. Denormalizing a
+        // collection property puts the Doctrine PersistentCollection in OBJECT_TO_POPULATE while
+        // $type is still the entity, so the instance check is what keeps this off anything that is
+        // not the object under construction.
+        $persistedCreatedAt = $objectToPopulate instanceof $type ? $this->getCreatedAt($objectToPopulate) : null;
 
         $object = $this->denormalizer->denormalize($data, $type, $format, $context);
+
+        if (null !== $persistedCreatedAt) {
+            $configuration = $this->annotationReader->getConfiguration($object);
+            $this->getClassMetadata($object)->setFieldValue($object, $configuration->createdAtField, $persistedCreatedAt);
+        }
+
         $this->timestampedDataPersister->persistTimestampedFields($object, $isNew);
 
         return $object;
+    }
+
+    private function getCreatedAt(object $object): ?\DateTimeInterface
+    {
+        $configuration = $this->annotationReader->getConfiguration($object);
+
+        return $this->getClassMetadata($object)->getFieldValue($object, $configuration->createdAtField);
     }
 
     public function getSupportedTypes(?string $format): array

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Silverback\ApiComponentsBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * `user.email_verification` used to declare `isRequired()` children under a node that carries a
+ * default value. ArrayNode::finalizeValue() inserts the default and skips finalisation for an
+ * omitted child, so those isRequired() checks never ran — the node resolved to `['enabled' => true]`
+ * and SilverbackApiComponentsExtension then read keys that were not there, emitting
+ * undefined-array-key warnings and wiring services with null. The same declaration made the node
+ * impossible to configure partially: supplying anything at all (including `enabled: false`) ran
+ * finalisation and hard-failed on the first missing required child.
+ *
+ * These tests pin the resolved configuration so every key the extension reads is always present.
+ *
+ * @author Daniel West <daniel@silverback.is>
+ */
+#[CoversClass(Configuration::class)]
+class ConfigurationTest extends TestCase
+{
+    /**
+     * The smallest configuration an application can supply. Everything the bundle does not force
+     * the application to declare must resolve to a usable default from here.
+     */
+    private static function minimalConfig(): array
+    {
+        return [
+            'refresh_token' => [
+                'handler_id' => 'silverback.api_components.refresh_token.storage.doctrine',
+                'cookie_name' => 'api_components',
+                'ttl' => 604800,
+                'database_user_provider' => 'database',
+            ],
+            'website_name' => 'Test Website',
+            'user' => ['class_name' => 'App\Entity\User'],
+            'publishable' => ['permission' => "is_granted('ROLE_ADMIN')"],
+        ];
+    }
+
+    private function process(array $config): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(), [$config]);
+    }
+
+    public function test_email_verification_resolves_every_key_the_extension_reads(): void
+    {
+        $emailVerification = $this->process(self::minimalConfig())['user']['email_verification'];
+
+        // SilverbackApiComponentsExtension::setEmailVerificationArguments() reads all four.
+        self::assertArrayHasKey('deny_unverified_login', $emailVerification);
+        self::assertArrayHasKey('default_value', $emailVerification);
+        self::assertArrayHasKey('verify_on_register', $emailVerification);
+        self::assertArrayHasKey('verify_on_change', $emailVerification);
+    }
+
+    public function test_email_verification_defaults_to_doing_nothing(): void
+    {
+        $emailVerification = $this->process(self::minimalConfig())['user']['email_verification'];
+
+        // An application that never mentions email verification must not start sending verification
+        // emails it has given no redirect target for, and must not have its users locked out of
+        // logging in.
+        self::assertFalse($emailVerification['verify_on_register']);
+        self::assertFalse($emailVerification['verify_on_change']);
+        self::assertFalse($emailVerification['deny_unverified_login']);
+        self::assertFalse($emailVerification['default_value']);
+    }
+
+    #[DataProvider('emailNodeProvider')]
+    public function test_email_redirect_keys_are_always_resolved(string $node): void
+    {
+        // SilverbackApiComponentsExtension::setMailerServiceArguments() reads both keys for each of
+        // these three nodes. The `email` node had no default of its own, so omitting the parent left
+        // no `email` key at all.
+        $email = $this->process(self::minimalConfig())['user'][$node]['email'];
+
+        self::assertArrayHasKey('default_redirect_path', $email);
+        self::assertArrayHasKey('redirect_path_query', $email);
+        self::assertNull($email['default_redirect_path']);
+        self::assertNull($email['redirect_path_query']);
+        self::assertNotEmpty($email['subject']);
+    }
+
+    public static function emailNodeProvider(): iterable
+    {
+        yield 'email verification' => ['email_verification'];
+        yield 'new email confirmation' => ['new_email_confirmation'];
+        yield 'password reset' => ['password_reset'];
+    }
+
+    public function test_email_verification_can_be_disabled(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = false;
+
+        self::assertFalse($this->process($config)['user']['email_verification']['enabled']);
+    }
+
+    public function test_email_verification_can_be_configured_partially(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = ['deny_unverified_login' => true];
+
+        $emailVerification = $this->process($config)['user']['email_verification'];
+
+        self::assertTrue($emailVerification['deny_unverified_login']);
+        self::assertFalse($emailVerification['verify_on_register']);
+    }
+
+    public function test_an_explicit_email_verification_config_is_preserved(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = [
+            'default_value' => false,
+            'verify_on_register' => true,
+            'verify_on_change' => true,
+            'deny_unverified_login' => true,
+            'email' => [
+                'redirect_path_query' => 'email_redirect',
+                'default_redirect_path' => '/verify-email/{{ username }}/{{ token }}',
+                'subject' => 'Verify please',
+            ],
+        ];
+
+        $emailVerification = $this->process($config)['user']['email_verification'];
+
+        self::assertTrue($emailVerification['enabled']);
+        self::assertFalse($emailVerification['default_value']);
+        self::assertTrue($emailVerification['verify_on_register']);
+        self::assertTrue($emailVerification['verify_on_change']);
+        self::assertTrue($emailVerification['deny_unverified_login']);
+        self::assertSame('/verify-email/{{ username }}/{{ token }}', $emailVerification['email']['default_redirect_path']);
+        self::assertSame('email_redirect', $emailVerification['email']['redirect_path_query']);
+        self::assertSame('Verify please', $emailVerification['email']['subject']);
+    }
+
+    #[DataProvider('verificationTriggerProvider')]
+    public function test_requesting_verification_emails_without_a_redirect_target_is_rejected(string $trigger): void
+    {
+        // AbstractUserEmailFactory::getTokenPath() throws when it has neither value, so this
+        // combination can only ever fail at the point a user registers. Fail at compile time
+        // instead.
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = [$trigger => true];
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('user.email_verification.email.default_redirect_path');
+
+        $this->process($config);
+    }
+
+    public static function verificationTriggerProvider(): iterable
+    {
+        yield 'on register' => ['verify_on_register'];
+        yield 'on change' => ['verify_on_change'];
+    }
+
+    public function test_requesting_verification_emails_with_only_a_redirect_query_key_is_allowed(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = [
+            'verify_on_register' => true,
+            'email' => ['redirect_path_query' => 'email_redirect'],
+        ];
+
+        $emailVerification = $this->process($config)['user']['email_verification'];
+
+        self::assertSame('email_redirect', $emailVerification['email']['redirect_path_query']);
+        self::assertNull($emailVerification['email']['default_redirect_path']);
+    }
+
+    public function test_a_disabled_email_verification_never_demands_a_redirect_target(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = ['enabled' => false, 'verify_on_register' => true];
+
+        self::assertFalse($this->process($config)['user']['email_verification']['enabled']);
+    }
+}

--- a/tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php
+++ b/tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php
@@ -74,8 +74,16 @@ class SilverbackApiComponentsExtensionTest extends TestCase
     }
 
     /**
-     * @return array{0: ContainerBuilder, 1: list<string>} the built container and any PHP
-     *                                                     errors raised while loading it
+     * Warnings and notices only. Reading a key that is not there raises E_WARNING, which is the
+     * symptom under test; deprecations are third-party noise (a lowest-dependencies MakerBundle
+     * raises one while its classes autoload here) and are handed back to the normal handler so the
+     * phpunit-bridge still accounts for them.
+     */
+    private const REPORTED_LEVELS = \E_WARNING | \E_NOTICE | \E_USER_WARNING | \E_USER_NOTICE;
+
+    /**
+     * @return array{0: ContainerBuilder, 1: list<string>} the built container and any warnings or
+     *                                                     notices raised while loading it
      */
     private function load(array $config): array
     {
@@ -86,6 +94,10 @@ class SilverbackApiComponentsExtensionTest extends TestCase
 
         $errors = [];
         set_error_handler(static function (int $errno, string $message) use (&$errors): bool {
+            if (!($errno & self::REPORTED_LEVELS)) {
+                return false;
+            }
+
             $errors[] = $message;
 
             return true;

--- a/tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php
+++ b/tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php
@@ -1,0 +1,277 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Silverback\ApiComponentsBundle\ApiPlatform\Metadata\Resource\RoutableResourceMetadataCollectionFactory;
+use Silverback\ApiComponentsBundle\ApiResource\ResourceManifest;
+use Silverback\ApiComponentsBundle\AttributeReader\UploadableAttributeReader;
+use Silverback\ApiComponentsBundle\DependencyInjection\SilverbackApiComponentsExtension;
+use Silverback\ApiComponentsBundle\Doctrine\Extension\ORM\RoutableExtension;
+use Silverback\ApiComponentsBundle\Doctrine\Extension\ORM\RouteExtension;
+use Silverback\ApiComponentsBundle\Doctrine\Extension\ORM\TablePrefixExtension;
+use Silverback\ApiComponentsBundle\Entity\Core\ComponentPosition;
+use Silverback\ApiComponentsBundle\Entity\Core\Route;
+use Silverback\ApiComponentsBundle\Factory\User\Mailer\ChangeEmailConfirmationEmailFactory;
+use Silverback\ApiComponentsBundle\Factory\User\Mailer\PasswordResetEmailFactory;
+use Silverback\ApiComponentsBundle\Factory\User\Mailer\VerifyEmailFactory;
+use Silverback\ApiComponentsBundle\Factory\User\Mailer\WelcomeEmailFactory;
+use Silverback\ApiComponentsBundle\Factory\User\UserFactory;
+use Silverback\ApiComponentsBundle\Helper\Publishable\PublishableStatusChecker;
+use Silverback\ApiComponentsBundle\Helper\User\UserDataProcessor;
+use Silverback\ApiComponentsBundle\Helper\User\UserMailer;
+use Silverback\ApiComponentsBundle\Mercure\MercureAuthorization;
+use Silverback\ApiComponentsBundle\Repository\User\UserRepositoryInterface;
+use Silverback\ApiComponentsBundle\Security\UserChecker;
+use Silverback\ApiComponentsBundle\Security\Voter\RoutableVoter;
+use Silverback\ApiComponentsBundle\Security\Voter\RouteVoter;
+use Silverback\ApiComponentsBundle\Security\Voter\SiteConfigParameterVoter;
+use Silverback\ApiComponentsBundle\Serializer\Normalizer\MetadataNormalizer;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpFoundation\Cookie;
+
+/**
+ * The extension reads `user.email_verification` keys straight out of the processed configuration.
+ * Those keys were declared `isRequired()` under a node carrying a default, so they were never
+ * enforced and never present: loading the extension emitted undefined-array-key warnings and wired
+ * the services with null. These tests load the extension against the smallest configuration an
+ * application can supply and assert that neither happens.
+ *
+ * @author Daniel West <daniel@silverback.is>
+ */
+#[CoversClass(SilverbackApiComponentsExtension::class)]
+class SilverbackApiComponentsExtensionTest extends TestCase
+{
+    /**
+     * `refresh_token.handler_id` deliberately avoids the doctrine storage: that branch reads
+     * `refresh_token.options.class`, an unrelated instance of the same latent pattern which is out
+     * of scope here and would otherwise trip the error handler below.
+     */
+    private static function minimalConfig(): array
+    {
+        return [
+            'refresh_token' => [
+                'handler_id' => 'app.refresh_token.storage',
+                'cookie_name' => 'api_components',
+                'ttl' => 604800,
+                'database_user_provider' => 'database',
+            ],
+            'website_name' => 'Test Website',
+            'user' => ['class_name' => 'App\Entity\User'],
+            'publishable' => ['permission' => "is_granted('ROLE_ADMIN')"],
+        ];
+    }
+
+    /**
+     * @return array{0: ContainerBuilder, 1: list<string>} the built container and any PHP
+     *                                                     errors raised while loading it
+     */
+    private function load(array $config): array
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', sys_get_temp_dir());
+        $container->setParameter('kernel.debug', false);
+        $container->setParameter('api_components.imagine_enabled', false);
+
+        $errors = [];
+        set_error_handler(static function (int $errno, string $message) use (&$errors): bool {
+            $errors[] = $message;
+
+            return true;
+        });
+
+        try {
+            (new SilverbackApiComponentsExtension())->load([$config], $container);
+        } finally {
+            restore_error_handler();
+        }
+
+        return [$container, $errors];
+    }
+
+    private function argument(ContainerBuilder $container, string $id, string $argument): mixed
+    {
+        $definition = $container->findDefinition($id);
+        self::assertInstanceOf(Definition::class, $definition);
+
+        return $definition->getArgument($argument);
+    }
+
+    public function test_loading_the_minimal_config_raises_no_php_errors(): void
+    {
+        [, $errors] = $this->load(self::minimalConfig());
+
+        self::assertSame([], $errors);
+    }
+
+    public function test_email_verification_services_are_never_wired_with_null(): void
+    {
+        [$container] = $this->load(self::minimalConfig());
+
+        self::assertFalse($this->argument($container, UserChecker::class, '$denyUnverifiedLogin'));
+        self::assertFalse($this->argument($container, UserDataProcessor::class, '$initialEmailVerifiedState'));
+        self::assertFalse($this->argument($container, UserDataProcessor::class, '$verifyEmailOnRegister'));
+        self::assertFalse($this->argument($container, UserDataProcessor::class, '$verifyEmailOnChange'));
+    }
+
+    public function test_an_explicit_email_verification_config_reaches_the_services(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = [
+            'default_value' => false,
+            'verify_on_register' => true,
+            'verify_on_change' => true,
+            'deny_unverified_login' => true,
+            'email' => ['default_redirect_path' => '/verify-email/{{ username }}/{{ token }}'],
+        ];
+
+        [$container, $errors] = $this->load($config);
+
+        self::assertSame([], $errors);
+        self::assertTrue($this->argument($container, UserChecker::class, '$denyUnverifiedLogin'));
+        self::assertFalse($this->argument($container, UserDataProcessor::class, '$initialEmailVerifiedState'));
+        self::assertTrue($this->argument($container, UserDataProcessor::class, '$verifyEmailOnRegister'));
+        self::assertTrue($this->argument($container, UserDataProcessor::class, '$verifyEmailOnChange'));
+        self::assertSame(
+            '/verify-email/{{ username }}/{{ token }}',
+            $this->argument($container, VerifyEmailFactory::class, '$defaultRedirectPath')
+        );
+    }
+
+    public function test_disabling_email_verification_disables_the_verification_email(): void
+    {
+        // canBeDisabled() was decorative: the flag could not be set (the node hard-failed on its
+        // required children) and VerifyEmailFactory was wired with a hardcoded true regardless.
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = false;
+
+        [$container] = $this->load($config);
+
+        self::assertFalse($this->argument($container, VerifyEmailFactory::class, '$enabled'));
+    }
+
+    public function test_the_verification_email_is_enabled_by_default(): void
+    {
+        [$container] = $this->load(self::minimalConfig());
+
+        self::assertTrue($this->argument($container, VerifyEmailFactory::class, '$enabled'));
+    }
+
+    public function test_defaulted_configuration_reaches_the_services_that_consume_it(): void
+    {
+        [$container] = $this->load(self::minimalConfig());
+
+        self::assertSame('_acb_', $this->argument($container, TablePrefixExtension::class, '$prefix'));
+        self::assertSame('_metadata', $this->argument($container, MetadataNormalizer::class, '$metadataKey'));
+        self::assertSame(3600, $this->argument($container, UserRepositoryInterface::class, '$passwordRequestTimeout'));
+        self::assertSame(86400, $this->argument($container, UserRepositoryInterface::class, '$newEmailConfirmTimeout'));
+        self::assertSame(86400, $this->argument($container, UserDataProcessor::class, '$tokenTtl'));
+        self::assertSame(604800, $container->getParameter('silverback.api_components.refresh_token.ttl'));
+
+        self::assertSame([], $this->argument($container, RouteExtension::class, '$config'));
+        self::assertSame([], $this->argument($container, RouteVoter::class, '$config'));
+        self::assertNull($this->argument($container, RoutableExtension::class, '$securityStr'));
+        self::assertNull($this->argument($container, RoutableVoter::class, '$securityStr'));
+        self::assertNull($this->argument($container, RoutableResourceMetadataCollectionFactory::class, '$securityStr'));
+
+        self::assertSame(Cookie::SAMESITE_STRICT, $this->argument($container, MercureAuthorization::class, '$cookieSameSite'));
+        self::assertNull($this->argument($container, MercureAuthorization::class, '$hubName'));
+        self::assertFalse($this->argument($container, MercureAuthorization::class, '$secureSubscriptions'));
+
+        self::assertSame(
+            [Route::class, ResourceManifest::class, ComponentPosition::class],
+            $this->argument($container, 'silverback.api_components.event_listener.api.cache_headers', '$personalisedResourceClasses')
+        );
+
+        self::assertFalse($this->argument($container, UploadableAttributeReader::class, '$imagineBundleEnabled'));
+    }
+
+    public function test_explicit_configuration_reaches_the_services_that_consume_it(): void
+    {
+        $config = self::minimalConfig();
+        $config['table_prefix'] = 'app_';
+        $config['metadata_key'] = '_meta';
+        $config['routable_security'] = "is_granted('ROLE_ADMIN')";
+        $config['route_security'] = [['route' => '/user-area*', 'security' => "is_granted('ROLE_USER')"]];
+        $config['mercure'] = ['hub_name' => 'default', 'secure_subscriptions' => true, 'cookie' => ['samesite' => Cookie::SAMESITE_LAX]];
+        $config['http_cache'] = ['personalised_resource_classes' => [Route::class]];
+        $config['user']['password_reset'] = ['repeat_ttl_seconds' => 60, 'request_timeout_seconds' => 120];
+        $config['user']['new_email_confirmation'] = ['request_timeout_seconds' => 180];
+
+        [$container, $errors] = $this->load($config);
+
+        self::assertSame([], $errors);
+        self::assertSame('app_', $this->argument($container, TablePrefixExtension::class, '$prefix'));
+        self::assertSame('_meta', $this->argument($container, MetadataNormalizer::class, '$metadataKey'));
+        self::assertSame('App\Entity\User', $this->argument($container, UserRepositoryInterface::class, '$entityClass'));
+        self::assertSame('App\Entity\User', $this->argument($container, UserFactory::class, '$userClass'));
+        self::assertSame(120, $this->argument($container, UserRepositoryInterface::class, '$passwordRequestTimeout'));
+        self::assertSame(180, $this->argument($container, UserRepositoryInterface::class, '$newEmailConfirmTimeout'));
+        self::assertSame(60, $this->argument($container, UserDataProcessor::class, '$tokenTtl'));
+
+        self::assertSame($config['route_security'], $this->argument($container, RouteVoter::class, '$config'));
+        self::assertSame("is_granted('ROLE_ADMIN')", $this->argument($container, RoutableVoter::class, '$securityStr'));
+        self::assertSame("is_granted('ROLE_ADMIN')", $this->argument($container, PublishableStatusChecker::class, '$permission'));
+        self::assertSame("is_granted('ROLE_ADMIN')", $this->argument($container, SiteConfigParameterVoter::class, '$permission'));
+
+        self::assertSame(Cookie::SAMESITE_LAX, $this->argument($container, MercureAuthorization::class, '$cookieSameSite'));
+        self::assertSame('default', $this->argument($container, MercureAuthorization::class, '$hubName'));
+        self::assertTrue($this->argument($container, MercureAuthorization::class, '$secureSubscriptions'));
+        self::assertSame([Route::class], $this->argument($container, 'silverback.api_components.event_listener.api.cache_headers', '$personalisedResourceClasses'));
+    }
+
+    public function test_the_mailer_subjects_default_and_can_be_overridden(): void
+    {
+        [$container] = $this->load(self::minimalConfig());
+
+        self::assertSame('Please verify your email', $this->argument($container, VerifyEmailFactory::class, '$subject'));
+        self::assertSame('Your password reset request', $this->argument($container, PasswordResetEmailFactory::class, '$subject'));
+        self::assertSame('Please confirm your new email address', $this->argument($container, ChangeEmailConfirmationEmailFactory::class, '$subject'));
+        self::assertSame('Welcome to {{ website_name }}', $this->argument($container, WelcomeEmailFactory::class, '$subject'));
+        self::assertTrue($this->argument($container, WelcomeEmailFactory::class, '$enabled'));
+        self::assertSame(['website_name' => 'Test Website'], $this->argument($container, UserMailer::class, '$context'));
+
+        // The other two are always available; only email_verification has a switch.
+        self::assertTrue($this->argument($container, PasswordResetEmailFactory::class, '$enabled'));
+        self::assertTrue($this->argument($container, ChangeEmailConfirmationEmailFactory::class, '$enabled'));
+    }
+
+    public function test_a_disabled_welcome_email_is_wired_as_disabled(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['emails'] = ['welcome' => ['enabled' => false, 'subject' => 'Hi']];
+
+        [$container] = $this->load($config);
+
+        self::assertFalse($this->argument($container, WelcomeEmailFactory::class, '$enabled'));
+        self::assertSame('Hi', $this->argument($container, WelcomeEmailFactory::class, '$subject'));
+    }
+
+    public function test_the_welcome_email_uses_the_email_verification_redirect(): void
+    {
+        $config = self::minimalConfig();
+        $config['user']['email_verification'] = [
+            'verify_on_register' => true,
+            'email' => [
+                'default_redirect_path' => '/verify/{{ token }}',
+                'redirect_path_query' => 'email_redirect',
+            ],
+        ];
+
+        [$container] = $this->load($config);
+
+        self::assertSame('/verify/{{ token }}', $this->argument($container, WelcomeEmailFactory::class, '$defaultRedirectPath'));
+        self::assertSame('email_redirect', $this->argument($container, WelcomeEmailFactory::class, '$redirectPathQueryKey'));
+    }
+}

--- a/tests/Functional/TestBundle/Entity/DummyUnguardedTimestamped.php
+++ b/tests/Functional/TestBundle/Entity/DummyUnguardedTimestamped.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\Functional\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Silverback\ApiComponentsBundle\Annotation as Silverback;
+use Silverback\ApiComponentsBundle\Entity\Utility\IdTrait;
+
+/**
+ * A #[Timestamped] resource that does NOT use TimestampedTrait.
+ *
+ * TimestampedTrait::setCreatedAt() silently ignores the new value once createdAt is set, which
+ * incidentally shields resources using the trait from a client-supplied createdAt. Nothing requires
+ * an application entity to use the trait or to write a guarded setter, so this entity exposes plain
+ * public properties — the shape the bundle must protect on its own.
+ *
+ * @author Daniel West <daniel@silverback.is>
+ */
+#[Silverback\Timestamped]
+#[ApiResource]
+#[ORM\Entity]
+class DummyUnguardedTimestamped
+{
+    use IdTrait;
+
+    public ?\DateTimeImmutable $createdAt = null;
+
+    public ?\DateTime $modifiedAt = null;
+}

--- a/tests/Serializer/MappingLoader/TimestampedLoaderTest.php
+++ b/tests/Serializer/MappingLoader/TimestampedLoaderTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\Serializer\MappingLoader;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Silverback\ApiComponentsBundle\Annotation as Silverback;
+use Silverback\ApiComponentsBundle\Serializer\MappingLoader\TimestampedLoader;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+
+/**
+ * @author Daniel West <daniel@silverback.is>
+ */
+#[CoversClass(TimestampedLoader::class)]
+class TimestampedLoaderTest extends TestCase
+{
+    private function loadGroups(string $class, string ...$attributes): array
+    {
+        $classMetadata = new ClassMetadata($class);
+        foreach ($attributes as $attribute) {
+            $classMetadata->addAttributeMetadata(new AttributeMetadata($attribute));
+        }
+
+        self::assertTrue((new TimestampedLoader())->loadClassMetadata($classMetadata));
+
+        $groups = [];
+        foreach ($classMetadata->getAttributesMetadata() as $name => $attributeMetadata) {
+            $groups[$name] = $attributeMetadata->getGroups();
+        }
+
+        return $groups;
+    }
+
+    public function test_created_at_is_readable_but_never_writable(): void
+    {
+        $groups = $this->loadGroups(TimestampedLoaderFixture::class, 'createdAt', 'modifiedAt');
+
+        // createdAt must not carry the write group: a resource declaring its own serialization
+        // groups would otherwise advertise the creation date as a writable input field.
+        self::assertSame(['TimestampedLoaderFixture:timestamped:read'], $groups['createdAt']);
+        self::assertSame(
+            ['TimestampedLoaderFixture:timestamped:read', 'TimestampedLoaderFixture:timestamped:write'],
+            $groups['modifiedAt']
+        );
+    }
+
+    public function test_custom_field_names_are_used(): void
+    {
+        $groups = $this->loadGroups(CustomTimestampedLoaderFixture::class, 'customCreatedAt', 'customModifiedAt', 'other');
+
+        self::assertSame(['CustomTimestampedLoaderFixture:timestamped:read'], $groups['customCreatedAt']);
+        self::assertSame(
+            ['CustomTimestampedLoaderFixture:timestamped:read', 'CustomTimestampedLoaderFixture:timestamped:write'],
+            $groups['customModifiedAt']
+        );
+        self::assertSame([], $groups['other']);
+    }
+
+    public function test_a_class_without_the_attribute_is_left_alone(): void
+    {
+        $groups = $this->loadGroups(PlainLoaderFixture::class, 'createdAt', 'modifiedAt');
+
+        self::assertSame([], $groups['createdAt']);
+        self::assertSame([], $groups['modifiedAt']);
+    }
+
+    public function test_attributes_that_already_declare_groups_are_left_alone(): void
+    {
+        $classMetadata = new ClassMetadata(TimestampedLoaderFixture::class);
+        $classMetadata->addAttributeMetadata($createdAt = new AttributeMetadata('createdAt'));
+        $createdAt->addGroup('existing:read');
+        $classMetadata->addAttributeMetadata($modifiedAt = new AttributeMetadata('modifiedAt'));
+        $modifiedAt->addGroup('existing:read');
+
+        (new TimestampedLoader())->loadClassMetadata($classMetadata);
+
+        self::assertSame(['existing:read'], $createdAt->getGroups());
+        self::assertSame(['existing:read'], $modifiedAt->getGroups());
+    }
+
+    public function test_missing_attribute_metadata_is_tolerated(): void
+    {
+        $groups = $this->loadGroups(TimestampedLoaderFixture::class);
+
+        self::assertSame([], $groups);
+    }
+}
+
+#[Silverback\Timestamped]
+class TimestampedLoaderFixture
+{
+    public ?\DateTimeImmutable $createdAt = null;
+    public ?\DateTime $modifiedAt = null;
+}
+
+#[Silverback\Timestamped(createdAtField: 'customCreatedAt', modifiedAtField: 'customModifiedAt')]
+class CustomTimestampedLoaderFixture
+{
+    public ?\DateTimeImmutable $customCreatedAt = null;
+    public ?\DateTime $customModifiedAt = null;
+    public ?string $other = null;
+}
+
+class PlainLoaderFixture
+{
+    public ?\DateTimeImmutable $createdAt = null;
+    public ?\DateTime $modifiedAt = null;
+}

--- a/tests/Serializer/Normalizer/TimestampedNormalizerTest.php
+++ b/tests/Serializer/Normalizer/TimestampedNormalizerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Silverback API Components Bundle Project
+ *
+ * (c) Daniel West <daniel@silverback.is>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silverback\ApiComponentsBundle\Tests\Serializer\Normalizer;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Silverback\ApiComponentsBundle\Annotation as Silverback;
+use Silverback\ApiComponentsBundle\AttributeReader\TimestampedAttributeReader;
+use Silverback\ApiComponentsBundle\Helper\Timestamped\TimestampedDataPersister;
+use Silverback\ApiComponentsBundle\Serializer\Normalizer\TimestampedNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @author Daniel West <daniel@silverback.is>
+ */
+#[CoversClass(TimestampedNormalizer::class)]
+class TimestampedNormalizerTest extends TestCase
+{
+    private function buildNormalizer(\Closure $denormalize): TimestampedNormalizer
+    {
+        $classMetadata = new ClassMetadata(TimestampedNormalizerFixture::class);
+        $classMetadata->initializeReflection(new RuntimeReflectionService());
+        $classMetadata->mapField(['fieldName' => 'createdAt', 'type' => 'datetime_immutable']);
+        $classMetadata->mapField(['fieldName' => 'modifiedAt', 'type' => 'datetime']);
+        $classMetadata->wakeupReflection(new RuntimeReflectionService());
+
+        $entityManager = $this->createStub(EntityManagerInterface::class);
+        $entityManager->method('getClassMetadata')->willReturn($classMetadata);
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($entityManager);
+
+        $reader = new TimestampedAttributeReader($registry);
+
+        $normalizer = new TimestampedNormalizer($registry, $reader, new TimestampedDataPersister($registry, $reader));
+
+        $inner = $this->createStub(DenormalizerInterface::class);
+        $inner->method('denormalize')->willReturnCallback(
+            static fn ($data, $type, $format = null, array $context = []) => $denormalize($context)
+        );
+        $normalizer->setDenormalizer($inner);
+
+        return $normalizer;
+    }
+
+    public function test_a_client_supplied_created_at_cannot_replace_the_persisted_one(): void
+    {
+        $persisted = new TimestampedNormalizerFixture();
+        $persisted->createdAt = new \DateTimeImmutable('2001-02-03 04:05:06');
+        $persisted->modifiedAt = new \DateTime('2001-02-03 04:05:06');
+
+        // The inner denormalizer writes the request body onto the managed object, as the real
+        // serializer does — by the time it returns, the original createdAt is already gone.
+        $normalizer = $this->buildNormalizer(static function (array $context) {
+            $object = $context[AbstractNormalizer::OBJECT_TO_POPULATE];
+            $object->createdAt = new \DateTimeImmutable('1970-01-01 00:00:00');
+
+            return $object;
+        });
+
+        $result = $normalizer->denormalize(
+            ['createdAt' => '1970-01-01 00:00:00'],
+            TimestampedNormalizerFixture::class,
+            null,
+            [AbstractNormalizer::OBJECT_TO_POPULATE => $persisted]
+        );
+
+        self::assertSame('2001-02-03 04:05:06', $result->createdAt->format('Y-m-d H:i:s'));
+        self::assertEqualsWithDelta(time(), $result->modifiedAt->getTimestamp(), 5);
+    }
+
+    public function test_a_new_resource_gets_a_fresh_created_at(): void
+    {
+        $normalizer = $this->buildNormalizer(static function () {
+            $object = new TimestampedNormalizerFixture();
+            $object->createdAt = new \DateTimeImmutable('1970-01-01 00:00:00');
+
+            return $object;
+        });
+
+        $result = $normalizer->denormalize(['createdAt' => '1970-01-01 00:00:00'], TimestampedNormalizerFixture::class);
+
+        self::assertEqualsWithDelta(time(), $result->createdAt->getTimestamp(), 5);
+        self::assertEqualsWithDelta(time(), $result->modifiedAt->getTimestamp(), 5);
+    }
+
+    public function test_an_object_to_populate_without_a_created_at_is_not_forced_back_to_null(): void
+    {
+        $persisted = new TimestampedNormalizerFixture();
+
+        $normalizer = $this->buildNormalizer(static function (array $context) {
+            $object = $context[AbstractNormalizer::OBJECT_TO_POPULATE];
+            $object->createdAt = new \DateTimeImmutable('1970-01-01 00:00:00');
+
+            return $object;
+        });
+
+        $result = $normalizer->denormalize(
+            ['createdAt' => '1970-01-01 00:00:00'],
+            TimestampedNormalizerFixture::class,
+            null,
+            [AbstractNormalizer::OBJECT_TO_POPULATE => $persisted]
+        );
+
+        self::assertSame('1970-01-01 00:00:00', $result->createdAt->format('Y-m-d H:i:s'));
+    }
+
+    public function test_an_object_to_populate_of_another_type_is_ignored(): void
+    {
+        // Denormalizing a collection property (e.g. ComponentGroup.pages) leaves the Doctrine
+        // PersistentCollection in OBJECT_TO_POPULATE while $type is still the entity class. Reading
+        // a creation date off it asks the attribute reader for a Timestamped configuration the
+        // collection does not have, which throws and turns the request into a 500.
+        $normalizer = $this->buildNormalizer(static function () {
+            $object = new TimestampedNormalizerFixture();
+            $object->createdAt = new \DateTimeImmutable('1970-01-01 00:00:00');
+
+            return $object;
+        });
+
+        $result = $normalizer->denormalize(
+            [],
+            TimestampedNormalizerFixture::class,
+            null,
+            [AbstractNormalizer::OBJECT_TO_POPULATE => new ArrayCollection()]
+        );
+
+        self::assertSame('1970-01-01 00:00:00', $result->createdAt->format('Y-m-d H:i:s'));
+    }
+
+    public function test_it_supports_a_timestamped_type_once_only(): void
+    {
+        $normalizer = $this->buildNormalizer(static fn () => new TimestampedNormalizerFixture());
+
+        self::assertTrue($normalizer->supportsDenormalization([], TimestampedNormalizerFixture::class));
+        self::assertFalse($normalizer->supportsDenormalization([], PlainNormalizerFixture::class));
+        self::assertFalse(
+            $normalizer->supportsDenormalization([], TimestampedNormalizerFixture::class, null, [
+                'TIMESTAMPED_NORMALIZER_ALREADY_CALLED' => [TimestampedNormalizerFixture::class],
+            ])
+        );
+    }
+
+    public function test_supported_types_are_not_cacheable(): void
+    {
+        $normalizer = $this->buildNormalizer(static fn () => new TimestampedNormalizerFixture());
+
+        self::assertSame(['object' => false], $normalizer->getSupportedTypes(null));
+    }
+}
+
+#[Silverback\Timestamped]
+class TimestampedNormalizerFixture
+{
+    public ?\DateTimeImmutable $createdAt = null;
+    public ?\DateTime $modifiedAt = null;
+}
+
+class PlainNormalizerFixture
+{
+}


### PR DESCRIPTION
Fixes #213 and #214. Both were raised by the documentation-accuracy audit from static reading; each turned out to be **real but not quite as described**, and the corrections changed which fix is correct. Details below.

One PR for both: they are the same class of defect (a guard that looks like it works but never runs) and the test suites overlap.

---

## #213 — `createdAt` is client-writable on write

### What the issue got right
`TimestampedDataPersister::persistTimestampedFields()` keeps whatever `createdAt` the object carries when it is not new, and by the time it runs the serializer has already written the request body onto that object. `modifiedAt` is correctly always overwritten.

### What the issue missed
**A `PATCH` carrying `createdAt` does *not* rewrite the creation date for any resource using `TimestampedTrait`.** `TimestampedTrait::setCreatedAt()` ignores the value once `createdAt` is set, and PropertyAccess prefers the setter over the public property. Every entity in the bundle uses the trait, which is why this has never been seen.

The bug is real for a resource that does **not** use the trait — an application entity with a plain property or an unguarded setter, which nothing obliges it to avoid. Added test entity `DummyUnguardedTimestamped` for exactly that shape. Behat, before the fix:

```
Scenario: I should not be able to overwrite createdAt with a PATCH request on a resource without a guarded setter
  And the JSON node "createdAt" should be equal to "2001-02-03T04:05:06+00:00"
    The node value is '"1970-01-01T00:00:00+00:00"' (Exception)
```

The equivalent scenario on `DummyTimestamped` (which uses the trait) passed before the fix and still passes.

### Which fix, and why
The issue offered two. **Dropping the write group is not sufficient on its own** — I implemented it alone first and the scenario still failed:

```
6 scenarios (5 passed, 1 failed)
```

`TimestampedContextBuilder` returns early when `$context['groups']` is empty, so a resource that declares no serialization groups gets no group filtering at all and `createdAt` stays writable regardless of the mapping loader.

So the enforcing fix is **capturing the value before denormalization** (`TimestampedNormalizer::denormalize`) and restoring it after. That works for every resource, grouped or not. I kept the write-group removal as well, since it stops the creation date being advertised as writable in the generated input schema — the project's least-exposure principle — but it is documentation, not enforcement.

`persistTimestampedFields($entity, true)` is untouched, so the `CwaFixtureBuilder` / `RouteGenerator` / `UserFactory` seeding paths behave exactly as before.

### One trap worth recording
The first version of the capture broke two unrelated Behat scenarios with a 500:

```
InvalidArgumentException: "Doctrine\ORM\PersistentCollection does not have
Silverback\ApiComponentsBundle\Annotation\Timestamped annotation"
```

Denormalizing a collection property (`ComponentGroup.pages`) leaves the **PersistentCollection** in `OBJECT_TO_POPULATE` while `$type` is still the entity class. The capture is now gated on `$objectToPopulate instanceof $type`, and `test_an_object_to_populate_of_another_type_is_ignored` pins it.

### Also in this commit (requested by the #215 author)
Two docblocks named a field that does not exist — `updatedAt`; it is `modifiedAt`. `UploadableLoader`'s was additionally a copy-paste describing the *timestamped* groups. Both corrected.

---

## #214 — required `user.email_verification` children are never enforced

### Verified, and worse than described
The mechanism is exactly as the issue says. Loading the extension against the smallest configuration an application can supply produced **26 PHP errors** and null-wired services:

```
Undefined array key "deny_unverified_login"
Undefined array key "default_value"
Undefined array key "verify_on_register"
Undefined array key "verify_on_change"
Undefined array key "email"
Trying to access array offset on null
...
Failed asserting that null is false.     (UserChecker::$denyUnverifiedLogin, typed bool)
```

Four things the issue did not mention:

1. **`new_email_confirmation` and `password_reset` are affected too.** Their `email` node has no `addDefaultsIfNotSet()`, so omitting either parent leaves no `email` key at all and the extension reads `['email']['default_redirect_path']` off a missing key.
2. **Even a fully-configured `email_verification` produced warnings** — `redirect_path_query` had no default, so it warned whenever it was not explicitly set.
3. **`canBeDisabled()` was unusable.** Supplying *anything*, including `enabled: false`, ran finalisation and hard-failed on the first missing required child. So the node was all-or-nothing: omit it entirely, or supply all five values.
4. **The `enabled` flag was ignored anyway** — `VerifyEmailFactory` was wired with a hardcoded `true`.

### The BC trade-off — please read this bit
**I did not make the children genuinely required.** That is the "correct" fix in the abstract and I deliberately rejected it: it would force every application that currently omits `user.email_verification` to add five keys, and the same for `password_reset` / `new_email_confirmation`. That is a breaking change for a defect that is invisible to those applications today.

Instead **every child now resolves to a value**. Applications that configure it are bit-for-bit unaffected (`test_an_explicit_email_verification_config_is_preserved`); applications that omit it stop getting warnings and null-wired services.

Defaults are **all-off** — `default_value`, `verify_on_register`, `verify_on_change`, `deny_unverified_login` all `false`, and `email.default_redirect_path` / `redirect_path_query` `null`. The reasoning:

- `deny_unverified_login: true` would lock every user out of an application that never configured verification. `UserChecker`'s own PHP default is `true`, but that default is unreachable — the extension always passes the argument — so it is not "current behaviour" in any meaningful sense.
- `verify_on_register: true` would start sending verification emails for which no redirect target has been given, and `AbstractUserEmailFactory::getTokenPath()` throws on that — turning a silent misconfiguration into a broken registration.
- `default_redirect_path: null` is *exactly* today's effective behaviour: `AbstractUserEmailFactory` already accepts `?string` and throws a clear `InvalidArgumentException` at send time. The only thing removed is the PHP warning.

Net effect for an application that omits the node: it previously had a `TypeError` waiting on first use of `UserChecker`/`UserDataProcessor`; it now has a coherent "email verification not in use" configuration.

### The one thing that does now fail loudly
Asking for verification emails (`verify_on_register` or `verify_on_change`) while giving neither `email.default_redirect_path` nor `email.redirect_path_query` is rejected at compile time by a node-level `validate()`. This is reachable **only when the node is present**, which is the only time the combination can be expressed at all — and that combination is already guaranteed to throw the moment a user registers. It cannot fire for any application that works today.

I did **not** extend that check to `password_reset` / `new_email_confirmation`: they have no on/off switch, so requiring their redirect paths would break applications that omit them.

### `enabled` is now honoured
`VerifyEmailFactory` receives `email_verification.enabled` instead of a hardcoded `true`. This cannot change any existing configuration's behaviour, because `enabled: false` was previously impossible to express — it threw.

### Deliberately left alone
Same latent pattern, all of which would require forcing configuration on existing applications, so they are a judgement call for you rather than something to slip into this PR:

- `user.class_name` (`isRequired()`, silently skipped when `user:` is omitted entirely)
- `refresh_token.handler_id` / `cookie_name` / `ttl` / `database_user_provider`
- `publishable.permission`
- `refresh_token.options.class`, read unguarded under the doctrine storage branch

Happy to open a follow-up issue for these if you want them tracked.

---

## Tests

| | before | after |
|---|---|---|
| PHPUnit | 607 | **637** passing, 113 pre-existing notices, 0 risky |
| Behat | 451 | **453** scenarios passing |
| Infection | ~85% | **85%** (`--min-covered-msi=80`) |

New: `tests/DependencyInjection/ConfigurationTest.php`, `tests/DependencyInjection/SilverbackApiComponentsExtensionTest.php`, `tests/Serializer/MappingLoader/TimestampedLoaderTest.php`, `tests/Serializer/Normalizer/TimestampedNormalizerTest.php`.

Every test was written first and observed failing. `ConfigurationTest` had 11 of 12 failing before the fix (the survivor being the "explicit config is preserved" regression guard, which should pass both before and after).

The DI tests use a bare `ContainerBuilder`, not `KernelTestCase` — no kernel boot, so no ErrorHandler and no risky test to abort Infection's initial run.

**On mutation score:** the new DI tests pull `Configuration.php` and `SilverbackApiComponentsExtension.php` into the covered set for the first time, so their mutants now count against MSI where `--only-covered` previously skipped them. That initially dropped MSI to 82%. Rather than exclude the files, I broadened the extension test to assert the wiring it actually performs, which brings it back to 85% — no headroom taken from other in-flight branches.

`codecov/patch` may report 0% for the Behat-only-covered parts of this change while the Behat coverage pipeline is being fixed (#218/#219). Scrutinizer is chronically red on this repo.
